### PR TITLE
added deploy with boreal to template readmes (closes PM-352)

### DIFF
--- a/templates/ads-b dlq/README.md
+++ b/templates/ads-b dlq/README.md
@@ -26,7 +26,11 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
+
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 ## Deploy on Boreal
 

--- a/templates/ads-b dlq/README.md
+++ b/templates/ads-b dlq/README.md
@@ -30,7 +30,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Boreal
 
-The easiest way to deploy your Moose app is to use the [Boreal](https://www.fiveonefour.com/boreal) from Fiveonefour, the creators of Moose and Sloan.
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 [Sign up](https://www.boreal.cloud/sign-up).
 

--- a/templates/ads-b dlq/README.md
+++ b/templates/ads-b dlq/README.md
@@ -1,23 +1,34 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with [`moose init`](https://docs.fiveonefour.com/moose/reference/moose-cli#init) or [`sloan init`](https://docs.fiveonefour.com/sloan/cli-reference#init)
+# Template: ADS-B DLQ Version
+
+This project processes and transforms aircraft tracking data from various sources into a standardized format for analysis and visualization. It currently pulls military aircraft data from adsb.lol.
+
+It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
+
+## DLQ Feature Demonstration
+
+This project intentionally implements an ingestion pipeline that successfully processes approximately ~90% of incoming aircraft data, with the remaining 10% being routed to a Dead Letter Queue (DLQ) (where the `alt_baro` field returns `ground` instead of an integer). This is to showcase Moose's DLQ capabilities and demonstrates how AI can be leveraged to handle data that doesn't conform to standard schemas or validation rules.
+
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
 ## Getting Started
 
-Prerequisites
+### Prerequisites
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 * [Node](https://nodejs.org/en)
 * [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
 * [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
+### Installation
+
 1. Install Moose / Sloan: `bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,sloan`
-2. Create project `sloan init aircraft ads-b`
+2. Create project: `sloan init aircraft ads-b-dlq`
 3. Install dependencies: `cd aircraft && npm install`
-5. Run Moose: `moose dev`
+4. Run Moose: `moose dev`
 
-You are ready to go!
-
-You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
-
-This project gets data from http://adsb.lol.
+You are ready to go! You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
 
 ## Learn More
 
@@ -26,11 +37,9 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
-
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 ## Deploy on Boreal
 
@@ -38,16 +47,6 @@ The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonef
 
 [Sign up](https://www.boreal.cloud/sign-up).
 
-# Template: ADS-B DLQ Version
-
-This project processes and transforms aircraft tracking data from various sources into a standardized format for analysis and visualization. It is currently only pulling from military aircraft.
-
-It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
-
-## DLQ Feature Demonstration
-
-This project intentionally implements an ingestion pipeline that successfully processes approximately ~90% of incoming aircraft data, with the remaining 10% being routed to a Dead Letter Queue (DLQ) (where the `alt_baro` field returns `ground` instead of an integer). This is to showcase Moose's DLQ capabilities and demonstrates how AI can be leveraged to handle data that doesn't conform to standard schemas or validation rules.
-
 ## License
 
-This template is MIT licenced.
+This template is MIT licensed.

--- a/templates/ads-b-cf/README.md
+++ b/templates/ads-b-cf/README.md
@@ -229,7 +229,7 @@ You can check out [the Moose GitHub repository](https://github.com/514-labs/moos
 
 ## Deploy on Boreal
 
-The easiest way to deploy your Moose app is to use the [Boreal](https://www.fiveonefour.com/boreal) from Fiveonefour, the creators of Moose and Sloan.
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 [Sign up](https://www.boreal.cloud/sign-up).
 

--- a/templates/ads-b-cf/README.md
+++ b/templates/ads-b-cf/README.md
@@ -227,6 +227,10 @@ To learn more about Moose, take a look at the following resources:
 
 You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
 
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+
 ## Deploy on Boreal
 
 The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.

--- a/templates/ads-b-cf/README.md
+++ b/templates/ads-b-cf/README.md
@@ -1,19 +1,26 @@
-# Aircraft Tracking System
+# Template: Aircraft Tracking System
 
-This is a [Moose](https://docs.fiveonefour.com/moose) project that processes and transforms aircraft tracking data from multiple sources into a unified format for analysis and visualization.
+This project processes and transforms aircraft tracking data from multiple sources into a unified format for analysis and visualization.
 
 This version of the ADS-B demo was created to highlight the new Connector Factory abstractions over connections.
 
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
+
 ## Getting Started
 
-Prerequisites
+### Prerequisites
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 * [Node](https://nodejs.org/en)
 * [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
 * [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
+### Installation
+
 1. Install Moose / Sloan: `bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,sloan`
-2. Create project `sloan init aircraft ads-b`
+2. Create project: `sloan init aircraft ads-b-cf`
 3. Install dependencies: `cd aircraft && npm install`
 4. Run Moose: `moose dev`
 5. Run Workflows: `moose workflow run militaryAircraftETL & moose workflow run laddAircraftETL & wait`
@@ -223,13 +230,10 @@ To learn more about Moose, take a look at the following resources:
 
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
-- [Deploy on Boreal](https://www.fiveonefour.com/boreal)
-
-You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 ## Deploy on Boreal
 

--- a/templates/ads-b-frontend/README.md
+++ b/templates/ads-b-frontend/README.md
@@ -1,6 +1,12 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with [`moose init`](https://docs.fiveonefour.com/moose/reference/moose-cli#init) or [`sloan init`](https://docs.fiveonefour.com/sloan/cli-reference#init)
+# Template: ADS-B Frontend
 
-This project is structured as follows
+This project processes and transforms aircraft tracking data from various sources into a standardized format for analysis and visualization. It currently pulls military aircraft data from adsb.lol.
+
+It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
+
+This project also has a seed frontend written in Node, to be used when generating frontend applications on top of this.
+
+This project is structured as follows:
 ```
 ads-b-frontend/
 ├── frontend/ # Frontend placeholder in Node
@@ -8,26 +14,30 @@ ads-b-frontend/
 └── README.md # Project documentation
 ```
 
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
+
 ## Getting Started
 
-Prerequisites
+### Prerequisites
+
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 * [Node](https://nodejs.org/en)
 * [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
 * [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
+### Installation
+
 1. Install Moose / Sloan: `bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,sloan`
-2. Create project `sloan init aircraft ads-b-frontend`
+2. Create project: `sloan init aircraft ads-b-frontend`
 3. Install dependencies: `cd aircraft/moose && npm install`
-5. Run Moose: `moose dev`
-6. In a new terminal, install frontend dependencies `cd aircraft/frontend && npm install`
-7. Run frontend: `npm run dev`
+4. Run Moose: `moose dev`
+5. In a new terminal, install frontend dependencies: `cd aircraft/frontend && npm install`
+6. Run frontend: `npm run dev`
 
-You are ready to go!
-
-You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
-
-This project gets data from http://adsb.lol.
+You are ready to go! You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
 
 ## Learn More
 
@@ -36,11 +46,9 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
-
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 ## Deploy on Boreal
 
@@ -48,15 +56,6 @@ The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonef
 
 [Sign up](https://www.boreal.cloud/sign-up).
 
-# Template: ADS-B
-
-This project processes and transforms aircraft tracking data from various sources into a standardized format for analysis and visualization. It is currently only pulling from military aircraft.
-
-It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
-
-This project also has a seed frontend written in Node, to be used when generating frontend applications on top of this.
-
 ## License
 
-This template is MIT licenced.
-
+This template is MIT licensed.

--- a/templates/ads-b-frontend/README.md
+++ b/templates/ads-b-frontend/README.md
@@ -40,7 +40,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Boreal
 
-The easiest way to deploy your Moose app is to use the [Boreal](https://www.fiveonefour.com/boreal) from Fiveonefour, the creators of Moose and Sloan.
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 [Sign up](https://www.boreal.cloud/sign-up).
 

--- a/templates/ads-b-frontend/README.md
+++ b/templates/ads-b-frontend/README.md
@@ -36,7 +36,11 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
+
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 ## Deploy on Boreal
 

--- a/templates/ads-b/README.md
+++ b/templates/ads-b/README.md
@@ -1,23 +1,29 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with [`moose init`](https://docs.fiveonefour.com/moose/reference/moose-cli#init) or [`sloan init`](https://docs.fiveonefour.com/sloan/cli-reference#init)
+# Template: ADS-B
+
+This project processes and transforms aircraft tracking data from various sources into a standardized format for analysis and visualization. It currently pulls military aircraft data from adsb.lol.
+
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
 ## Getting Started
 
-Prerequisites
+### Prerequisites
+
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 * [Node](https://nodejs.org/en)
 * [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
 * [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
+### Installation
+
 1. Install Moose / Sloan: `bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,sloan`
-2. Create project `sloan init aircraft ads-b`
+2. Create project: `sloan init aircraft ads-b`
 3. Install dependencies: `cd aircraft && npm install`
-5. Run Moose: `moose dev`
+4. Run Moose: `moose dev`
 
-You are ready to go!
-
-You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
-
-This project gets data from http://adsb.lol.
+You are ready to go! You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
 
 ## Learn More
 
@@ -26,11 +32,9 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
-
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 ## Deploy on Boreal
 
@@ -38,12 +42,6 @@ The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonef
 
 [Sign up](https://www.boreal.cloud/sign-up).
 
-# Template: ADS-B
-
-This project processes and transforms aircraft tracking data from various sources into a standardized format for analysis and visualization. It is currently only pulling from military aircraft.
-
-It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
-
 ## License
 
-This template is MIT licenced.
+This template is MIT licensed.

--- a/templates/ads-b/README.md
+++ b/templates/ads-b/README.md
@@ -26,7 +26,11 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
+
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 ## Deploy on Boreal
 

--- a/templates/ads-b/README.md
+++ b/templates/ads-b/README.md
@@ -30,7 +30,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Boreal
 
-The easiest way to deploy your Moose app is to use the [Boreal](https://www.fiveonefour.com/boreal) from Fiveonefour, the creators of Moose and Sloan.
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 [Sign up](https://www.boreal.cloud/sign-up).
 

--- a/templates/brainwaves/README.md
+++ b/templates/brainwaves/README.md
@@ -196,7 +196,7 @@ For more details, see the code and comments in each app's `src/` directory.
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 # Deploy on Boreal
 

--- a/templates/brainwaves/README.md
+++ b/templates/brainwaves/README.md
@@ -193,3 +193,9 @@ GROUP BY sessionId;
 ---
 
 For more details, see the code and comments in each app's `src/` directory.
+
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.

--- a/templates/brainwaves/README.md
+++ b/templates/brainwaves/README.md
@@ -194,6 +194,10 @@ GROUP BY sessionId;
 
 For more details, see the code and comments in each app's `src/` directory.
 
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+
 # Deploy on Boreal
 
 The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.

--- a/templates/github-dev-trends/Readme.md
+++ b/templates/github-dev-trends/Readme.md
@@ -134,3 +134,7 @@ Once both backend and frontend are deployed and configured correctly, your live 
 The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).

--- a/templates/github-dev-trends/Readme.md
+++ b/templates/github-dev-trends/Readme.md
@@ -1,6 +1,4 @@
-# GitHub Trending Topics Template
-
-<a href="https://www.docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+# Template: GitHub Trending Topics
 
 This template provides a real-time dashboard tracking trending repositories and topics on GitHub. It collects and analyzes Star Events from the public GitHub events feed using Moose for the backend and a separate dashboard application for the frontend.
 
@@ -10,7 +8,14 @@ This template provides a real-time dashboard tracking trending repositories and 
 
 **Documentation:** [Template Documentation](https://docs.fiveonefour.com/templates/github)
 
-## Prerequisites
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
+
+## Getting Started
+
+### Prerequisites
 
 *   Node.js (Minimum version 20+)
 *   pnpm (Minimum version 8+)
@@ -34,7 +39,7 @@ This is a pnpm monorepo with the following structure:
 └── template.config.toml  # Template specific configuration
 ```
 
-## Setup
+### Installation
 
 If you haven't already, install the Moose CLI and pnpm:
 ```bash copy
@@ -45,18 +50,18 @@ bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose
 npm install -g pnpm
 ```
 
-### 1. Initialize the Project
+1. Initialize the Project
 ```bash copy
 moose init moose-github-dev-trends github-dev-trends
 ```
 
-### 2. Install Dependencies
+2. Install Dependencies
 ```bash copy
 cd moose-github-dev-trends
 pnpm install
 ```
 
-### 3. Moose Backend Setup
+3. Moose Backend Setup
 
 *   Set the GitHub Personal Access Token:
     *   This project requires a [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) to access the GitHub API for fetching event data.
@@ -68,7 +73,7 @@ pnpm install
     *   This will start the Moose backend service containing the local infrastructure (Redpanda, ClickHouse, Temporal, Webserver) and the GitHub event poller.
     *   You can verify that it's running by checking the Moose logs in your terminal.
 
-### 4. Frontend Dashboard Setup
+4. Frontend Dashboard Setup
 
 *   Open a **new terminal** and start the frontend dashboard:
     ```bash copy
@@ -137,4 +142,4 @@ Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moos
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).

--- a/templates/github-dev-trends/Readme.md
+++ b/templates/github-dev-trends/Readme.md
@@ -128,3 +128,9 @@ Deploying this project involves deploying the Moose backend service and the fron
 *   **Deploy:** Vercel will build and deploy your Next.js frontend.
 
 Once both backend and frontend are deployed and configured correctly, your live GitHub Trends Dashboard should be accessible via the Vercel deployment URL.
+
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.

--- a/templates/github-dev-trends/apps/moose-backend/README.md
+++ b/templates/github-dev-trends/apps/moose-backend/README.md
@@ -8,7 +8,7 @@
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accelerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 

--- a/templates/github-dev-trends/apps/moose-backend/README.md
+++ b/templates/github-dev-trends/apps/moose-backend/README.md
@@ -1,14 +1,14 @@
 # This is a [MooseJs](https://www.moosejs.com/) project bootstrapped with the 
 [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
 
-<a href="https://www.getmoose.dev/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+<a href="https://docs.fiveonefour.com/moose/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
 [![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
-[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.moosejs.com/)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://www.getmoose.dev/) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 

--- a/templates/goodreads/README.md
+++ b/templates/goodreads/README.md
@@ -27,7 +27,11 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
+
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 ## Deploy on Boreal
 

--- a/templates/goodreads/README.md
+++ b/templates/goodreads/README.md
@@ -1,24 +1,34 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with [`moose init`](https://docs.fiveonefour.com/moose/reference/moose-cli#init) or [`sloan init`](https://docs.fiveonefour.com/sloan/cli-reference#init)
+# Template: Goodreads
+
+This project contains data models for storing and processing Goodreads book information.
+
+It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
+
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
 ## Getting Started
 
-Prerequisites
+### Prerequisites
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 * [Node](https://nodejs.org/en)
 * [A Kaggle API Key](https://www.kaggle.com/docs/api)
 * [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
 * [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
+### Installation
+
 1. Install Moose / Sloan: `bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,sloan`
-2. Create project `sloan init books goodreads`
+2. Create project: `sloan init books goodreads`
 3. Install dependencies: `cd books && npm install`
-4. Add your Kaggle Settings file to authenticate (For more information, see https://www.kaggle.com/docs/api)
+4. Add your Kaggle Settings file to authenticate (For more information, see [Kaggle API docs](https://www.kaggle.com/docs/api))
 5. Run Moose: `moose dev`
+
 You are ready to go!
 
 You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
-
-This project gets data from http://adsb.lol.
 
 ## Learn More
 
@@ -27,11 +37,9 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
-
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 ## Deploy on Boreal
 
@@ -39,12 +47,6 @@ The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonef
 
 [Sign up](https://www.boreal.cloud/sign-up).
 
-# Template: Goodreads
-
-This project contains data models for storing and processing Goodreads book information.
-
-It has example workflows, data models and streaming functions. If you want to explore egress primitives, try using [Sloan](https://docs.fiveonefour.com/sloan) to generate them.
-
 ## License
 
-This template is MIT licenced.
+This template is MIT licensed.

--- a/templates/goodreads/README.md
+++ b/templates/goodreads/README.md
@@ -31,7 +31,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Boreal
 
-The easiest way to deploy your Moose app is to use the [Boreal](https://www.fiveonefour.com/boreal) from Fiveonefour, the creators of Moose and Sloan.
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 [Sign up](https://www.boreal.cloud/sign-up).
 

--- a/templates/live-heartrate-leaderboard/README.md
+++ b/templates/live-heartrate-leaderboard/README.md
@@ -34,7 +34,7 @@
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 # Deploy on Boreal
 

--- a/templates/live-heartrate-leaderboard/README.md
+++ b/templates/live-heartrate-leaderboard/README.md
@@ -31,3 +31,9 @@
 ## SOS
 
 `docker stop $(docker ps -aq)`
+
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.

--- a/templates/live-heartrate-leaderboard/README.md
+++ b/templates/live-heartrate-leaderboard/README.md
@@ -32,6 +32,10 @@
 
 `docker stop $(docker ps -aq)`
 
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+
 # Deploy on Boreal
 
 The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.

--- a/templates/next-app-empty/README.md
+++ b/templates/next-app-empty/README.md
@@ -1,33 +1,40 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with [`moose init`](https://docs.fiveonefour.com/moose/reference/moose-cli#init) or [`sloan init`](https://docs.fiveonefour.com/sloan/cli-reference#init)
+# Template: Next.js App (Empty)
 
-This project is structured as follows
+This is an empty template that combines a Next.js frontend with a Moose backend. It provides a starting point for building full-stack applications with real-time data processing capabilities.
+
+It has placeholder data models and basic project structure.
+
+This project is structured as follows:
 ```
 next-app-empty/
-├── frontend/ # Frontend placeholder in Node
-├── moose/ # Backend services
-└── README.md # Project documentation
+├── frontend/  # Frontend placeholder in Node
+├── moose/     # Backend services
+└── README.md  # Project documentation
 ```
+
+[![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
+[![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
+[![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
 ## Getting Started
 
-Prerequisites
+### Prerequisites
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 * [Node](https://nodejs.org/en)
 * [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
 * [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
+### Installation
+
 1. Install Moose / Sloan: `bash -i <(curl -fsSL https://fiveonefour.com/install.sh) moose,sloan`
-2. Create project `sloan init <project-name> next-app-empty`
+2. Create project: `sloan init <project-name> next-app-empty`
 3. Install dependencies: `cd <project-name>/moose && npm install`
 4. Run Moose: `moose dev`
-5. In a new terminal, install frontend dependencies `cd <project-name>/frontend && npm install`
-7. Run frontend: `npm run dev`
+5. In a new terminal, install frontend dependencies: `cd <project-name>/frontend && npm install`
+6. Run frontend: `npm run dev`
 
-You are ready to go!
-
-You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
-
-This project gets data from http://adsb.lol.
+You are ready to go! You can start editing the app by modifying primitives in the `app` subdirectory. The dev server auto-updates as you edit the file.
 
 ## Learn More
 
@@ -36,11 +43,9 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
-
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 ## Deploy on Boreal
 
@@ -50,5 +55,4 @@ The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonef
 
 ## License
 
-This template is MIT licenced.
-
+This template is MIT licensed.

--- a/templates/next-app-empty/README.md
+++ b/templates/next-app-empty/README.md
@@ -40,7 +40,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Boreal
 
-The easiest way to deploy your Moose app is to use the [Boreal](https://www.fiveonefour.com/boreal) from Fiveonefour, the creators of Moose and Sloan.
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
 [Sign up](https://www.boreal.cloud/sign-up).
 

--- a/templates/next-app-empty/README.md
+++ b/templates/next-app-empty/README.md
@@ -36,7 +36,11 @@ To learn more about Moose, take a look at the following resources:
 - [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
 - [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+You can check out [the Moose GitHub repository](https://github.com/514-labs/moose) - your feedback and contributions are welcome!
+
+## Community
+
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 ## Deploy on Boreal
 

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -1,37 +1,48 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with the
-[`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
+# Template: Python (Empty)
 
-<a href="https://docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+This is an empty Python-based Moose template that provides a minimal foundation for building data-intensive applications using Python.
 
 [![PyPI Version](https://img.shields.io/pypi/v/moose-cli?logo=python)](https://pypi.org/project/moose-cli/)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+## Getting Started
 
-# Get started with Moose
+### Prerequisites
 
-Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.fiveonefour.com/moose/getting-started/quickstart). We also have our [Docs](https://docs.fiveonefour.com/moose) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+* [Python](https://www.python.org/downloads/) (version 3.8+)
+* [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
+* [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
-# Beta release
+### Installation
 
-Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.fiveonefour.com/moose/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
+1. Install Moose CLI: `pip install moose-cli`
+2. Create project: `moose init <project-name> python-empty`
+3. Install dependencies: `cd <project-name> && pip install -r requirements.txt`
+4. Run Moose: `moose dev`
+
+You are ready to go! You can start editing the app by modifying primitives in the `app` subdirectory.
+
+## Learn More
+
+To learn more about Moose, take a look at the following resources:
+
+- [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
+- [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+## Deploy on Boreal
 
 The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up](https://www.boreal.cloud/sign-up).
 
-# Contributing
+## License
 
-We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).
+This template is MIT licensed.
 
-# Made by 514
-
-Our mission at [fiveonefour](https://www.fiveonefour.com/) is to bring incredible developer experiences to the data stack. If you’re interested in enterprise solutions, commercial support, or design partnerships, then we’d love to chat with you: [hello@moosejs.dev](mailto:hello@moosejs.dev)

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -24,6 +24,12 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
 
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+
 # Contributing
 
 We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).

--- a/templates/python-empty/README.md
+++ b/templates/python-empty/README.md
@@ -1,28 +1,26 @@
-This is a [Moose](https://www.docs.fiveonefour.com/moose) project bootstrapped with the
+This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with the
 [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
 
-<a href="https://www.docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+<a href="https://docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
 [![PyPI Version](https://img.shields.io/pypi/v/moose-cli?logo=python)](https://pypi.org/project/moose-cli/)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
-[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://www.docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 
-Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.getmoose.dev/getting-started/quickstart). We also have our [Docs](https://docs.getmoose.dev) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
+Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.fiveonefour.com/moose/getting-started/quickstart). We also have our [Docs](https://docs.fiveonefour.com/moose) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
 
 # Beta release
 
-Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.getmoose.dev/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
+Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.fiveonefour.com/moose/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
 
-# Community
+## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg).
-
-Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 # Deploy on Boreal
 

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -24,6 +24,12 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
 
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+
 # Contributing
 
 We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -1,37 +1,48 @@
-This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with the
-[`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
+# Template: Python
 
-<a href="https://docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+This is a Python-based Moose template that provides a foundation for building data-intensive applications using Python.
 
 [![PyPI Version](https://img.shields.io/pypi/v/moose-cli?logo=python)](https://pypi.org/project/moose-cli/)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+## Getting Started
 
-# Get started with Moose
+### Prerequisites
 
-Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.fiveonefour.com/moose/getting-started/quickstart). We also have our [Docs](https://docs.fiveonefour.com/moose) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+* [Python](https://www.python.org/downloads/) (version 3.8+)
+* [An Anthropic API Key](https://docs.anthropic.com/en/api/getting-started)
+* [Cursor](https://www.cursor.com/) or [Claude Desktop](https://claude.ai/download)
 
-# Beta release
+### Installation
 
-Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.fiveonefour.com/moose/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
+1. Install Moose CLI: `pip install moose-cli`
+2. Create project: `moose init <project-name> python`
+3. Install dependencies: `cd <project-name> && pip install -r requirements.txt`
+4. Run Moose: `moose dev`
+
+You are ready to go! You can start editing the app by modifying primitives in the `app` subdirectory.
+
+## Learn More
+
+To learn more about Moose, take a look at the following resources:
+
+- [Moose Documentation](https://docs.fiveonefour.com/moose) - learn about Moose.
+- [Sloan Documentation](https://docs.fiveonefour.com/sloan) - learn about Sloan, the MCP interface for data engineering.
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
-# Deploy on Boreal
+## Deploy on Boreal
 
 The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
 
-Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+[Sign up](https://www.boreal.cloud/sign-up).
 
-# Contributing
+## License
 
-We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).
+This template is MIT licensed.
 
-# Made by 514
-
-Our mission at [fiveonefour](https://www.fiveonefour.com/) is to bring incredible developer experiences to the data stack. If you’re interested in enterprise solutions, commercial support, or design partnerships, then we’d love to chat with you: [hello@moosejs.dev](mailto:hello@moosejs.dev)

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -1,28 +1,26 @@
-This is a [Moose](https://www.docs.fiveonefour.com/moose) project bootstrapped with the
+This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with the
 [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
 
-<a href="https://www.docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+<a href="https://docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
 [![PyPI Version](https://img.shields.io/pypi/v/moose-cli?logo=python)](https://pypi.org/project/moose-cli/)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
-[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://www.docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 
-Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.getmoose.dev/getting-started/quickstart). We also have our [Docs](https://docs.getmoose.dev) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
+Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.fiveonefour.com/moose/getting-started/quickstart). We also have our [Docs](https://docs.fiveonefour.com/moose) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
 
 # Beta release
 
-Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.getmoose.dev/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
+Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.fiveonefour.com/moose/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
 
-# Community
+## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg).
-
-Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 # Deploy on Boreal
 

--- a/templates/typescript-empty/README.md
+++ b/templates/typescript-empty/README.md
@@ -23,6 +23,12 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
 
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+
 # Contributing
 
 We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).

--- a/templates/typescript-empty/README.md
+++ b/templates/typescript-empty/README.md
@@ -19,7 +19,7 @@ Moose is beta software and is in active development. Multiple public companies a
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 # Deploy on Boreal
 

--- a/templates/typescript-empty/README.md
+++ b/templates/typescript-empty/README.md
@@ -1,27 +1,25 @@
-# This is a [MooseJs](https://www.moosejs.com/) project bootstrapped with the [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
+# This is a [MooseJs](https://docs.fiveonefour.com/moose) project bootstrapped with the [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
 
-<a href="https://www.getmoose.dev/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+<a href="https://docs.fiveonefour.com/moose"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
 [![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
-[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.moosejs.com/)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://www.getmoose.dev/) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 
-Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.getmoose.dev/quickstart). We also have our [Docs](https://docs.getmoose.dev/) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
+Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.fiveonefour.com/moose/getting-started/quickstart). We also have our [Docs](https://docs.fiveonefour.com/moose) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
 
 # Beta release
 
-Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.getmoose.dev/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
+Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.fiveonefour.com/moose/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
 
-# Community
+## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg).
-
-Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 # Deploy on Boreal
 

--- a/templates/typescript-empty/README.md
+++ b/templates/typescript-empty/README.md
@@ -7,7 +7,7 @@
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accelerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 

--- a/templates/typescript/README.md
+++ b/templates/typescript/README.md
@@ -23,6 +23,12 @@ You can join the Moose community [on Slack](https://join.slack.com/t/moose-commu
 
 Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
 
+# Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use [Boreal](https://www.fiveonefour.com/boreal) from 514 Labs, the creators of Moose.
+
+Check out our [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for more details.
+
 # Contributing
 
 We welcome contributions to Moose! Please check out the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).

--- a/templates/typescript/README.md
+++ b/templates/typescript/README.md
@@ -1,27 +1,25 @@
-# This is a [MooseJs](https://www.moosejs.com/) project bootstrapped with the [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
+# This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with the [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
 
-<a href="https://www.getmoose.dev/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
+<a href="https://docs.fiveonefour.com/moose/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
 [![NPM Version](https://img.shields.io/npm/v/%40514labs%2Fmoose-cli?logo=npm)](https://www.npmjs.com/package/@514labs/moose-cli?activeTab=readme)
 [![Moose Community](https://img.shields.io/badge/slack-moose_community-purple.svg?logo=slack)](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
-[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.moosejs.com/)
+[![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://www.getmoose.dev/) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 
-Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.getmoose.dev/quickstart). We also have our [Docs](https://docs.getmoose.dev/) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
+Get up and running with your own Moose project in minutes by using our [Quick Start Tutorial](https://docs.fiveonefour.com/moose/getting-started/quickstart). We also have our [Docs](https://docs.fiveonefour.com/moose) where you can pick your path, learn more about Moose, and learn what types of applications can be built with Moose.
 
 # Beta release
 
-Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We’d love for you to [get your hands on it and try it out](https://docs.getmoose.dev/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
+Moose is beta software and is in active development. Multiple public companies across the globe are using Moose in production. We'd love for you to [get your hands on it and try it out](https://docs.fiveonefour.com/moose/getting-started/quickstart). If you're interested in using Moose in production, or if you just want to chat, you can reach us at [hello@moosejs.dev](mailto:hello@moosejs.dev) or in the Moose developer community below.
 
-# Community
+## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg).
-
-Here you can get together with other Moose developers, ask questions, give feedback, make feature requests, and interact directly with Moose maintainers.
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
 
 # Deploy on Boreal
 

--- a/templates/typescript/README.md
+++ b/templates/typescript/README.md
@@ -7,7 +7,7 @@ This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with 
 [![Docs](https://img.shields.io/badge/quick_start-docs-blue.svg)](https://docs.fiveonefour.com/moose/getting-started/quickstart)
 [![MIT license](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accellerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
+[Moose](https://docs.fiveonefour.com/moose) is an open-source data engineering framework designed to drastically accelerate AI-enabled software developers, as you prototype and scale data-intensive features and applications.
 
 # Get started with Moose
 

--- a/templates/typescript/README.md
+++ b/templates/typescript/README.md
@@ -1,4 +1,4 @@
-# This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with the [`Moose CLI`](https://github.com/514-labs/moose/tree/main/apps/framework-cli).
+This is a [Moose](https://docs.fiveonefour.com/moose) project bootstrapped with [`moose init`](https://docs.fiveonefour.com/moose/reference/moose-cli#init) or [`sloan init`](https://docs.fiveonefour.com/sloan/cli-reference#init)
 
 <a href="https://docs.fiveonefour.com/moose/"><img src="https://raw.githubusercontent.com/514-labs/moose/main/logo-m-light.png" alt="moose logo" height="100px"></a>
 
@@ -19,7 +19,7 @@ Moose is beta software and is in active development. Multiple public companies a
 
 ## Community
 
-You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moose).
+You can join the Moose community [on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg). Check out the [MooseStack repo on GitHub](https://github.com/514-labs/moosestack).
 
 # Deploy on Boreal
 


### PR DESCRIPTION
This pull request updates the deployment instructions for several project templates to clarify the branding and provide more helpful documentation links. The main changes include updating the reference to the creators of Boreal from "Fiveonefour" to "514 Labs," and adding or improving sections about deploying Moose apps on Boreal, including links to the official deployment documentation.

**Branding and attribution updates:**

* Updated the deployment instructions in multiple `README.md` files to refer to "514 Labs" as the creators of Moose and Boreal instead of "Fiveonefour." [[1]](diffhunk://#diff-06041d676f234e08e5bec7fcb9b43aac018d7b7c6494d9aab5f3d650ef457b80L33-R33) [[2]](diffhunk://#diff-0c830d68ff4cdfb9c808eb0233cba2daee900d0cf99805c8a8f14e10c3e96985L232-R232) [[3]](diffhunk://#diff-89cd81510d8a22a4681422f96bee02bf34d429cca39cf71501fc5e5e8cc95bfbL43-R43) [[4]](diffhunk://#diff-81a249c04004c65ff226d0b37788e8b235c08692d9bdcd597d400dafc5612396L33-R33) [[5]](diffhunk://#diff-1b8d61b4f871e8415dcb9a0fda666477d27cf549dfb041c499365a8f49168e9bL34-R34) [[6]](diffhunk://#diff-c249603d43e25c3c2282ce723f28aaa38cc1b59f9dcfea3bac409b9134cba9e9L43-R43)

**Deployment documentation improvements:**

* Added or enhanced a "Deploy on Boreal" section in several templates, providing a clear link to [Boreal](https://www.fiveonefour.com/boreal) and the [Moose deployment documentation](https://docs.fiveonefour.com/moose/deploying) for further guidance. [[1]](diffhunk://#diff-87d3f301d8113c97edcac032c3db054a6727d78244f93f002dabcd01d80fdb13R196-R201) [[2]](diffhunk://#diff-7f0ae1883016a4a4a1a404b4d01202f97e6a393870d8afb00d1b2251aae027e7R131-R136) [[3]](diffhunk://#diff-92c61fd720ec2a47a46dbc03ff5316d899c6c1ead4e02c1cabdb39bfb21fb370R34-R39) [[4]](diffhunk://#diff-12d37d36f566bb721f3118ef7a6802273d880324838289b781c89b075b5fe781R27-R32) [[5]](diffhunk://#diff-1d0d0fce4397b53f6b609031e15b3b52654bc9d3f12b440a0d1d34097aaffcb6R26-R31)