### PR TITLE
template print boreal referece (closes PM-357)

### DIFF
--- a/templates/ads-b dlq/template.config.toml
+++ b/templates/ads-b dlq/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "Real-time aircraft transponder data. Error in data model sends data to a DLQ (this is intentional)."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/ads-b-cf/template.config.toml
+++ b/templates/ads-b-cf/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "Real-time aircraft transponder data."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/ads-b-frontend/template.config.toml
+++ b/templates/ads-b-frontend/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "Real-time aircraft transponder data, with a frontend."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 🫎 Initialize Moose project
 
 📂 Go to your moose project:

--- a/templates/ads-b/template.config.toml
+++ b/templates/ads-b/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "Real-time aircraft transponder data."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/brainwaves/template.config.toml
+++ b/templates/brainwaves/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "A brainwave capture and analysis system"
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 This is a Moose application for working with Brainwave Data.
 
 To get started, follow these steps:
@@ -13,6 +22,5 @@ To get started, follow these steps:
 
 🛠️ Start dev server:
     $ moose dev
-
 """
 default_sloan_telemetry="comprehensive"

--- a/templates/github-dev-trends/template.config.toml
+++ b/templates/github-dev-trends/template.config.toml
@@ -1,6 +1,14 @@
 language = "typescript" # Must be typescript or python
 description = "A real-time look at top trending topics on GitHub. Collects & analyzes Star Events from the public events feed"
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
 
 📂 Go to your project directory:
     $ cd {project_dir}

--- a/templates/goodreads/template.config.toml
+++ b/templates/goodreads/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "A template ingesting goodreads data from Kaggle"
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/live-heartrate-leaderboard/template.config.toml
+++ b/templates/live-heartrate-leaderboard/template.config.toml
@@ -1,6 +1,15 @@
 language = "python" # Must be typescript or python
 description = "live heart rate leaderboard. Inspired by F45"
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/next-app-empty/template.config.toml
+++ b/templates/next-app-empty/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "A typescript project with a NextJS frontend (empty)."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}/moose
 

--- a/templates/python-empty/template.config.toml
+++ b/templates/python-empty/template.config.toml
@@ -1,6 +1,15 @@
 language = "python" # Must be typescript or python
 description = "Empty python project."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/python/template.config.toml
+++ b/templates/python/template.config.toml
@@ -1,6 +1,15 @@
 language = "python" # Must be typescript or python
 description = "default python project"
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/typescript-empty/template.config.toml
+++ b/templates/typescript-empty/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "Empty typescript project."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 

--- a/templates/typescript/template.config.toml
+++ b/templates/typescript/template.config.toml
@@ -1,6 +1,15 @@
 language = "typescript" # Must be typescript or python
 description = "Default typescript project."
 post_install_print = """
+Deploy on Boreal
+
+The easiest way to deploy your Moose app is to use Boreal
+from the creators of MooseStack.
+
+https://boreal.cloud
+
+---------------------------------------------------------
+
 📂 Go to your project directory:
     $ cd {project_dir}
 


### PR DESCRIPTION
This pull request updates the post-install instructions across multiple project templates to include information about deploying Moose apps using Boreal, a deployment platform from the creators of MooseStack. The new instructions provide a link to Boreal and position it as the easiest deployment option for users.

Deployment instructions update:

* Added a "Deploy on Boreal" section to the `post_install_print` field in the following template configuration files, guiding users to use Boreal for deploying their Moose apps and providing the relevant URL:
  - `templates/ads-b/template.config.toml`
  - `templates/ads-b dlq/template.config.toml`
  - `templates/ads-b-cf/template.config.toml`
  - `templates/ads-b-frontend/template.config.toml`
  - `templates/brainwaves/template.config.toml`
  - `templates/github-dev-trends/template.config.toml`
  - `templates/goodreads/template.config.toml`
  - `templates/live-heartrate-leaderboard/template.config.toml`
  - `templates/next-app-empty/template.config.toml`
  - `templates/python-empty/template.config.toml`
  - `templates/python/template.config.toml`
  - `templates/typescript-empty/template.config.toml`
  - `templates/typescript/template.config.toml`