### PR TITLE
Reformat Slack Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ consumption_api = ConsumptionApi[RequestParams, DataModel]("get-api-route", quer
 
 ## Community
 
-Join us on Slack: https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg
+[Join us on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
 
 ## Contributing
 


### PR DESCRIPTION
This pull request makes a minor improvement to the `README.md` by updating the Slack community link to use Markdown link formatting for better readability and consistency.

- Updated the Slack invite link in the Community section to use Markdown link syntax instead of a plain URL.