### PR TITLE
Nicolas/fix backward compatibility

### DIFF
--- a/packages/py-moose-lib/moose_lib/dmv2/__init__.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/__init__.py
@@ -46,6 +46,9 @@ from .consumption import (
     Api,
     get_moose_base_url,
     set_moose_base_url,
+    # Backward compatibility aliases
+    ConsumptionApi,
+    EgressConfig,
 )
 
 from .sql_resource import (
@@ -85,6 +88,9 @@ from .registry import (
     get_sql_resource,
     get_workflows,
     get_workflow,
+    # Backward compatibility aliases
+    get_consumption_apis,
+    get_consumption_api,
 )
 
 __all__ = [
@@ -123,6 +129,9 @@ __all__ = [
     'Api',
     'get_moose_base_url',
     'set_moose_base_url',
+    # Backward compatibility aliases (deprecated)
+    'ConsumptionApi',
+    'EgressConfig',
 
     # SQL
     'SqlResource',
@@ -152,4 +161,7 @@ __all__ = [
     'get_sql_resource',
     'get_workflows',
     'get_workflow',
+    # Backward compatibility aliases (deprecated)
+    'get_consumption_apis',
+    'get_consumption_api',
 ]

--- a/packages/py-moose-lib/moose_lib/dmv2/consumption.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/consumption.py
@@ -228,3 +228,11 @@ class Api(BaseTypedResource, Generic[U]):
         # Parse JSON response and return as the expected type
         response_data = response.json()
         return self._u.model_validate(response_data)
+
+
+# Backward compatibility aliases (deprecated)
+ConsumptionApi = Api
+"""@deprecated: Use Api instead of ConsumptionApi"""
+
+EgressConfig = ApiConfig
+"""@deprecated: Use ApiConfig instead of EgressConfig"""

--- a/packages/py-moose-lib/moose_lib/dmv2/registry.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/registry.py
@@ -71,3 +71,11 @@ def get_workflows() -> Dict[str, Workflow]:
 def get_workflow(name: str) -> Optional[Workflow]:
     """Get a registered workflow by name."""
     return _workflows.get(name)
+
+
+# Backward compatibility aliases (deprecated)
+get_consumption_apis = get_apis
+"""@deprecated: Use get_apis instead of get_consumption_apis"""
+
+get_consumption_api = get_api
+"""@deprecated: Use get_api instead of get_consumption_api"""

--- a/packages/py-moose-lib/moose_lib/main.py
+++ b/packages/py-moose-lib/moose_lib/main.py
@@ -147,6 +147,11 @@ class ApiResult:
     body: Any
 
 
+# Backward compatibility alias (deprecated)
+ConsumptionApiResult = ApiResult
+"""@deprecated: Use ApiResult instead of ConsumptionApiResult"""
+
+
 class QueryClient:
     """Client for executing queries, typically against ClickHouse.
 

--- a/packages/ts-moose-lib/src/browserCompatible.ts
+++ b/packages/ts-moose-lib/src/browserCompatible.ts
@@ -15,6 +15,8 @@ export {
   IngestConfig,
   Api,
   ApiConfig,
+  ConsumptionApi,
+  EgressConfig,
   IngestPipeline,
   SqlResource,
   View,
@@ -35,6 +37,6 @@ export {
   ClickHouseNamedTuple,
 } from "./dataModels/types";
 
-export type { ApiUtil } from "./consumption-apis/helpers";
+export type { ApiUtil, ConsumptionUtil } from "./consumption-apis/helpers";
 
 export * from "./sqlHelpers";

--- a/packages/ts-moose-lib/src/consumption-apis/helpers.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/helpers.ts
@@ -20,6 +20,9 @@ export interface ApiUtil {
   jwt: JWTPayload | undefined;
 }
 
+/** @deprecated Use ApiUtil instead. */
+export type ConsumptionUtil = ApiUtil;
+
 export class MooseClient {
   query: QueryClient;
   workflow: WorkflowClient;
@@ -287,6 +290,9 @@ export const ApiHelpers = {
   column: (value: string) => ["Identifier", value] as [string, string],
   table: (value: string) => ["Identifier", value] as [string, string],
 };
+
+/** @deprecated Use ApiHelpers instead. */
+export const ConsumptionHelpers = ApiHelpers;
 
 export function joinQueries({
   values,

--- a/packages/ts-moose-lib/src/consumption-apis/runner.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/runner.ts
@@ -67,6 +67,9 @@ export function createApi<T extends object, R = any>(
   );
 }
 
+/** @deprecated Use `Api` from "dmv2/sdk/consumptionApi" instead. */
+export const createConsumptionApi = createApi;
+
 const apiHandler = async (
   publicKey: jose.KeyLike | undefined,
   clickhouseClient: ClickHouseClient,
@@ -78,6 +81,7 @@ const apiHandler = async (
 ) => {
   const apis = isDmv2 ? await getApis() : new Map();
   return async (req: http.IncomingMessage, res: http.ServerResponse) => {
+
     try {
       const url = new URL(req.url || "", "http://localhost");
       const fileName = url.pathname;

--- a/packages/ts-moose-lib/src/consumption-apis/typiaValidation.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/typiaValidation.ts
@@ -57,7 +57,7 @@ export const isCreateApiV2 = (
   }
 
   const sym = checker.getSymbolAtLocation(node.expression);
-  return sym?.name === "Api";
+  return sym?.name === "Api" || sym?.name === "ConsumptionApi";
 };
 
 const getParamType = (

--- a/packages/ts-moose-lib/src/dmv2/index.ts
+++ b/packages/ts-moose-lib/src/dmv2/index.ts
@@ -35,7 +35,12 @@ export {
 export { Workflow, Task } from "./sdk/workflow";
 
 export { IngestApi, IngestConfig } from "./sdk/ingestApi";
-export { Api, ApiConfig } from "./sdk/consumptionApi";
+export {
+  Api,
+  ApiConfig,
+  EgressConfig,
+  ConsumptionApi,
+} from "./sdk/consumptionApi";
 export { IngestPipeline, IngestPipelineConfig } from "./sdk/ingestPipeline";
 export { ETLPipeline, ETLPipelineConfig } from "./sdk/etlPipeline";
 export {

--- a/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
@@ -120,3 +120,9 @@ export class Api<T, R = any> extends TypedBase<T, ApiConfig<T>> {
     return data as R;
   }
 }
+
+/** @deprecated Use ApiConfig<T> directly instead. */
+export type EgressConfig<T> = ApiConfig<T>;
+
+/** @deprecated Use Api directly instead. */
+export const ConsumptionApi = Api;

--- a/packages/ts-moose-lib/src/index.ts
+++ b/packages/ts-moose-lib/src/index.ts
@@ -16,11 +16,11 @@ export * from "./commons";
 export * from "./consumption-apis/helpers";
 export * from "./scripts/task";
 
-export { createApi } from "./consumption-apis/runner";
+export { createApi, createConsumptionApi } from "./consumption-apis/runner";
 
 export { MooseCache } from "./clients/redisClient";
 
-export { ApiUtil } from "./consumption-apis/helpers";
+export { ApiUtil, ConsumptionUtil } from "./consumption-apis/helpers";
 
 export * from "./utilities";
 export * from "./connectors/dataSource";


### PR DESCRIPTION
This pull request introduces a set of backward compatibility aliases in both the Python and TypeScript Moose libraries. The main goal is to help users transition from deprecated "Consumption" naming to the new "Api" naming, while maintaining support for older codebases. The changes are primarily the addition of deprecated aliases and updates to exports, with no changes to core functionality.

**Python library (`py-moose-lib`) backward compatibility:**

* Added deprecated aliases: `ConsumptionApi` for `Api`, `EgressConfig` for `ApiConfig`, `get_consumption_apis` for `get_apis`, and `get_consumption_api` for `get_api` in `moose_lib/dmv2/__init__.py`, `consumption.py`, and `registry.py` [[1]](diffhunk://#diff-82bc40261dd3968801e600b7c64af9b0a8330ec9d382df6b01c507344c4a0a8cR49-R51) [[2]](diffhunk://#diff-82bc40261dd3968801e600b7c64af9b0a8330ec9d382df6b01c507344c4a0a8cR91-R93) [[3]](diffhunk://#diff-82bc40261dd3968801e600b7c64af9b0a8330ec9d382df6b01c507344c4a0a8cR132-R134) [[4]](diffhunk://#diff-82bc40261dd3968801e600b7c64af9b0a8330ec9d382df6b01c507344c4a0a8cR164-R166) [[5]](diffhunk://#diff-4404051e5eb855b431cbc929dcba1e75d657b0e2ef306a622e633c01093ad3beR231-R238) [[6]](diffhunk://#diff-dd6eba6713130ab737b4d26dfdf3e9a6bf7442ec69e9722c9f18ccdeba27726cR74-R81).
* Added `ConsumptionApiResult` as a deprecated alias for `ApiResult` in `main.py`.

**TypeScript library (`ts-moose-lib`) backward compatibility:**

* Added deprecated exports: `ConsumptionApi` for `Api`, `EgressConfig` for `ApiConfig`, and corresponding aliases in `browserCompatible.ts` and `dmv2/index.ts` [[1]](diffhunk://#diff-5da630b25bbb469e3c8bb6f0d1d65e9724c08e02196b33ed07a84f2885c8fa28R18-R19) [[2]](diffhunk://#diff-55a487a0b56270f0260fd84a2999ca6446618091d61ba37f25326f30ca7f6b44L38-R43).
* Introduced `ConsumptionUtil` as a deprecated alias for `ApiUtil`, and `ConsumptionHelpers` for `ApiHelpers` in `consumption-apis/helpers.ts` [[1]](diffhunk://#diff-7fe8c7b68a4b1f027f6399e2002bb48d01b95f66b0178726ebac2a2117f3b50dR23-R25) [[2]](diffhunk://#diff-7fe8c7b68a4b1f027f6399e2002bb48d01b95f66b0178726ebac2a2117f3b50dR294-R296).
* Added `createConsumptionApi` as a deprecated alias for `createApi` in `consumption-apis/runner.ts` and updated exports [[1]](diffhunk://#diff-7c2569e186a7d509b84a6378fb6740fdbb50251ae3fe4f07542a2845e07ad3ddR70-R72) [[2]](diffhunk://#diff-aea3f9f2f4939caf26fc9afeb56dbbd9e0bebd01fc89a590d514083f93de5a4eL19-R23).
* Updated type validation to recognize both `Api` and `ConsumptionApi` in `typiaValidation.ts`.
* Added and exported deprecated types and constants in `consumptionApi.ts`.

These changes ensure that any code using the older "Consumption" APIs will continue to work, but users are encouraged to migrate to the new "Api" naming going forward.