### PR TITLE
Document export pattern across docs (quickstart and primitives) (closes PM-382)

### DIFF
--- a/apps/framework-docs/src/components/export-requirement.tsx
+++ b/apps/framework-docs/src/components/export-requirement.tsx
@@ -16,22 +16,27 @@ export function ExportRequirement({
     <Callout type="info" title="Export Required" compact>
       <TypeScript>
         <p>
-          Ensure your {primitive.toLowerCase()} is correctly imported into your{" "}
+          Ensure your {primitive} is correctly exported from your{" "}
           <code>app/index.ts</code> file.
         </p>
       </TypeScript>
       <Python>
         <p>
-          Ensure your {primitive.toLowerCase()} is correctly imported into your{" "}
+          Ensure your {primitive} is correctly imported into your{" "}
           <code>main.py</code> file.
         </p>
       </Python>
       <p>
+        Learn more about export pattern:{" "}
         <Link
-          href="/moose/local-dev#quick-example"
+          href="/moose/local-dev#hot-reloading-development"
           className="text-blue-500 hover:underline"
         >
-          Learn more about the export pattern →
+          local development
+        </Link>
+        {" / "}
+        <Link href="/moose/migrate" className="text-blue-500 hover:underline">
+          hosted.
         </Link>
       </p>
     </Callout>

--- a/apps/framework-docs/src/components/export-requirement.tsx
+++ b/apps/framework-docs/src/components/export-requirement.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Callout } from "./callout";
+import Link from "next/link";
+import { TypeScript, Python } from "./language-wrappers";
+
+interface ExportRequirementProps {
+  primitive: string;
+  example?: string;
+}
+
+export function ExportRequirement({
+  primitive,
+  example,
+}: ExportRequirementProps) {
+  return (
+    <Callout type="info" title="Export Required" compact>
+      <TypeScript>
+        <p>
+          Ensure your {primitive.toLowerCase()} is correctly imported into your{" "}
+          <code>app/index.ts</code> file.
+        </p>
+      </TypeScript>
+      <Python>
+        <p>
+          Ensure your {primitive.toLowerCase()} is correctly imported into your{" "}
+          <code>main.py</code> file.
+        </p>
+      </Python>
+      <p>
+        <Link
+          href="/moose/local-dev#quick-example"
+          className="text-blue-500 hover:underline"
+        >
+          Learn more about the export pattern →
+        </Link>
+      </p>
+    </Callout>
+  );
+}

--- a/apps/framework-docs/src/components/index.tsx
+++ b/apps/framework-docs/src/components/index.tsx
@@ -16,3 +16,4 @@ export * from "./ctas";
 export * from "./contact";
 export * from "./staggered-card";
 export * from "./animate-ui/buttons/github-stars";
+export * from "./export-requirement";

--- a/apps/framework-docs/src/pages/moose/apis.mdx
+++ b/apps/framework-docs/src/pages/moose/apis.mdx
@@ -3,7 +3,7 @@ title: Moose APIs
 description: Create type-safe ingestion and analytics APIs for data access and integration
 ---
 
-import { Callout, LanguageSwitcher, BulletPointsCard, CheckmarkBullets, TypeScript, Python, CTACards, CTACard } from "@/components";
+import { Callout, LanguageSwitcher, BulletPointsCard, CheckmarkBullets, TypeScript, Python, CTACards, CTACard, ExportRequirement } from "@/components";
 import { Tabs } from "nextra/components";
 
 # Moose APIs
@@ -42,6 +42,8 @@ The APIs module provides standalone HTTP endpoints for data ingestion and analyt
 
 ## Basic Examples
 
+<ExportRequirement primitive="API" example="export { userEventsApi, userDataApi }" />
+
 ### Ingestion API
 
 <TypeScript>
@@ -56,7 +58,7 @@ interface UserEvent {
 }
 
 // Create a standalone ingestion API
-const userEventsApi = new IngestApi<UserEvent>("user-events", {
+export const userEventsApi = new IngestApi<UserEvent>("user-events", {
   destination: eventStream
 });
 ```
@@ -76,6 +78,8 @@ class UserEvent(BaseModel):
 
 # Create a standalone ingestion API
 user_events_api = IngestApi[UserEvent]("user-events", IngestConfig(destination=event_stream))
+
+# No export needed - Python modules are automatically discovered
 ```
 </Python>
 
@@ -97,7 +101,7 @@ interface ResultData {
 }
 
 // Create a standalone analytics API
-const userDataApi = new Api<Params, ResultData[]>("user-data", 
+export const userDataApi = new Api<Params, ResultData[]>("user-data", 
   async ({ userId, limit }, { client, sql }) => {
     // Query external service or custom logic
     return [
@@ -128,6 +132,8 @@ def query_function(client: MooseClient, params: QueryParams) -> list[UserData]:
     return client.query.execute(sql)
 
 user_data_api = Api[Params, ResultData]("get-data", query_function)
+
+# No export needed - Python modules are automatically discovered
 ```
 </Python>
 

--- a/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
@@ -46,7 +46,7 @@ const SourceTable = SourcePipeline.table!; // Use `!` to assert that the table i
 const cols = SourceTable.columns;
 
 // Define the result type as an array of the result item type
-const exampleApi = new Api<QueryParams, ResultItem[]>("example_endpoint",  
+export const exampleApi = new Api<QueryParams, ResultItem[]>("example_endpoint",  
     async ({ filterField, maxResults }: QueryParams, { client, sql }) => {
         const query = sql`
         SELECT 

--- a/apps/framework-docs/src/pages/moose/apis/ingest-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/ingest-api.mdx
@@ -42,7 +42,7 @@ interface ExampleModel {
   }
 }
 
-const api = new IngestApi<ExampleModel>("your-api-route", {
+export const api = new IngestApi<ExampleModel>("your-api-route", {
   destination: new Stream<ExampleModel>("your-stream-name"),
   deadLetterQueue: new DeadLetterQueue<ExampleModel>("your-dlq-name")
 });

--- a/apps/framework-docs/src/pages/moose/getting-started/from-clickhouse.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/from-clickhouse.mdx
@@ -210,6 +210,11 @@ Check what Moose created from your tables in the `app/main.py` file:
 <FileTree.File name="main.py" />
 </FileTree.Folder>
 </FileTree>
+
+<Callout type="info" title="Import Pattern">
+<div>Your generated table models are imported here so Moose can detect them.</div>
+<div className="text-sm mt-2">Learn more about export pattern: <a href="/moose/local-dev#hot-reloading-development" className="text-blue-500 hover:underline">local development</a> / <a href="/moose/migrate" className="text-blue-500 hover:underline">hosted</a></div>
+</Callout>
 </Python>
 
 <TypeScript>
@@ -219,6 +224,11 @@ Check what Moose created from your tables in the `app/index.ts` file:
 <FileTree.File name="index.ts" />
 </FileTree.Folder>
 </FileTree>
+
+<Callout type="info" title="Export Pattern">
+<div>Your generated table models are exported here so Moose can detect them.</div>
+<div className="text-sm mt-2">Learn more about export pattern: <a href="/moose/local-dev#hot-reloading-development" className="text-blue-500 hover:underline">local development</a> / <a href="/moose/migrate" className="text-blue-500 hover:underline">hosted</a></div>
+</Callout>
 </TypeScript>
 
 <br />

--- a/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
+++ b/apps/framework-docs/src/pages/moose/getting-started/quickstart.mdx
@@ -192,6 +192,11 @@ Your project includes a complete example pipeline:
 </FileTree.Folder>
 </FileTree.Folder>
 </FileTree>
+
+<Callout type="info" title="Import Pattern">
+<div>The `main.py` file imports all your data components so Moose can detect them.</div>
+<div className="text-sm mt-2">Learn more about export pattern: <a href="/moose/local-dev#hot-reloading-development" className="text-blue-500 hover:underline">local development</a> / <a href="/moose/migrate" className="text-blue-500 hover:underline">hosted</a></div>
+</Callout>
 </Python>
 
 <TypeScript>
@@ -210,6 +215,11 @@ Your project includes a complete example pipeline:
 </FileTree.Folder>
 </FileTree.Folder>
 </FileTree>
+
+<Callout type="info" title="Export Pattern">
+<div>The `index.ts` file exports all your data components so Moose can detect them.</div>
+<div className="text-sm mt-2">Learn more about export pattern: <a href="/moose/local-dev#hot-reloading-development" className="text-blue-500 hover:underline">local development</a> / <a href="/moose/migrate" className="text-blue-500 hover:underline">hosted</a></div>
+</Callout>
 </TypeScript>
 
 <Callout type="info" title="Browse your project files" >

--- a/apps/framework-docs/src/pages/moose/local-dev.mdx
+++ b/apps/framework-docs/src/pages/moose/local-dev.mdx
@@ -75,6 +75,7 @@ Only the root file in your `app/` directory is run when changes are detected. In
 
 ## Quick Example
 
+<TypeScript>
 **❌ Doesn't work - No export from root:**
 ```ts file="app/tables/users.ts"
 import { UserSchema } from './schemas/user';
@@ -84,20 +85,41 @@ const usersTable = new OlapTable<UserSchema>("Users");
 ```
 
 **✅ Works - Export from root file:**
-```ts file="app/tables/users.ts" {5}
+```ts file="app/tables/users.ts" {3}
 import { UserSchema } from './schemas/user';
 
-const usersTable = new OlapTable<UserSchema>("Users");
-
-export { usersTable }; // add this line to export the table
+export const usersTable = new OlapTable<UserSchema>("Users");
 ```
 
 ```ts file="app/index.ts"
-import { usersTable } from './tables/users';
-export { usersTable };  // Moose sees this
+export * from './tables/users';  // Moose sees this
 ```
 
 Now because we exported the table from the root file, Moose will detect the change and rebuild the table.
+</TypeScript>
+
+<Python>
+**❌ Doesn't work - No export from root:**
+```py file="app/tables/users.py"
+from schemas.user import UserSchema
+
+users_table = OlapTable[UserSchema]("Users")
+# Moose can't see this - not imported in main.py
+```
+
+**✅ Works - Import in main file:**
+```py file="app/tables/users.py" {3}
+from schemas.user import UserSchema
+
+users_table = OlapTable[UserSchema]("Users")  # No export needed - Python modules are automatically discovered
+```
+
+```py file="app/main.py"
+from tables.users import users_table  # Moose sees this
+```
+
+Now because we imported the table in the main file, Moose will detect the change and rebuild the table.
+</Python>
 
 
 **✅ Works - Change dependency:**

--- a/apps/framework-docs/src/pages/moose/local-dev.mdx
+++ b/apps/framework-docs/src/pages/moose/local-dev.mdx
@@ -70,7 +70,12 @@ The file watcher recursively monitors your entire `app/` directory structure and
 </Python>
 
 <Callout type="info" title="Only Runs Your Root File">
-Only the root file in your `app/` directory is run when changes are detected. In order for your tables/streams/apis/workflows to be detected, you must export them from your root file. If you change a file in your app directory and it is a dependency of your root file, then those changes WILL be detected.
+<TypeScript>
+Only the root file in your `app/` directory is run when changes are detected. In order for your tables/streams/apis/workflows to be detected, you must export them from your root file (`app/index.ts`). If you change a file in your app directory and it is a dependency of your root file, then those changes WILL be detected.
+</TypeScript>
+<Python>
+Only the root file in your `app/` directory is run when changes are detected. In order for your tables/streams/apis/workflows to be detected, you must import them in your root file (`main.py`). If you change a file in your app directory and it is a dependency of your root file, then those changes WILL be detected.
+</Python>
 </Callout>
 
 ## Quick Example

--- a/apps/framework-docs/src/pages/moose/olap.mdx
+++ b/apps/framework-docs/src/pages/moose/olap.mdx
@@ -3,7 +3,7 @@ title: Moose OLAP
 description: Create and manage ClickHouse tables, materialized views, and data migrations
 ---
 
-import { Callout, BulletPointsCard, CheckmarkBullets, LanguageSwitcher, TypeScript, Python, CTACards, CTACard, PathConfig } from "@/components";
+import { Callout, BulletPointsCard, CheckmarkBullets, LanguageSwitcher, TypeScript, Python, CTACards, CTACard, PathConfig, ExportRequirement } from "@/components";
 import { Tabs } from "nextra/components";
 
 # Moose OLAP
@@ -13,17 +13,9 @@ import { Tabs } from "nextra/components";
 
 The Moose OLAP module provides standalone ClickHouse database management with type-safe schemas. You can use this capability independently to create tables, materialized views, and manage your table schemas without requiring other MooseStack components.
 
-
-## Enabling Moose OLAP
-
-In your `moose.config.toml` file, enable the OLAP Database capability:
-
-```toml
-[features]
-olap = true
-```
-
 ### Basic Example
+
+<ExportRequirement primitive="OlapTable" example="export { myTable }" />
 
 <TypeScript>
 ```ts filename="FirstTable.ts" copy
@@ -34,7 +26,7 @@ interface MyFirstTable {
 }
 
 // Create a table named "first_table"
-const myTable = new OlapTable<MyFirstTable>("first_table");
+export const myTable = new OlapTable<MyFirstTable>("first_table");
 ```
 </TypeScript>
 
@@ -50,8 +42,19 @@ class MyFirstTable(BaseModel):
 
 # Create a table named "first_table"
 my_table = OlapTable[MyFirstTable]("first_table") 
+
+# No export needed - Python modules are automatically discovered
 ```
 </Python>
+
+## Enabling Moose OLAP
+
+In your `moose.config.toml` file, enable the OLAP Database capability:
+
+```toml
+[features]
+olap = true
+```
 
 ## Core Capabilities
 

--- a/apps/framework-docs/src/pages/moose/olap/model-materialized-view.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-materialized-view.mdx
@@ -28,7 +28,7 @@ interface TargetSchema {
   average_rating: number;
   num_reviews: number;
 }
-const mv = new MaterializedView<TargetSchema>({
+export const mv = new MaterializedView<TargetSchema>({
   // The transformation to run on the source table
   selectStatement: sql`
   SELECT

--- a/apps/framework-docs/src/pages/moose/olap/model-table.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-table.mdx
@@ -27,7 +27,7 @@ interface MyFirstTable {
 }
 
 // Create a table named "first_table"
-const myTable = new OlapTable<MyFirstTable>("first_table");
+export const myTable = new OlapTable<MyFirstTable>("first_table");
 ```
 </TypeScript>
 
@@ -45,6 +45,7 @@ class MyFirstTable(BaseModel):
 # Create a table named "first_table"
 my_table = OlapTable[MyFirstTable]("first_table") 
 
+# No export needed - Python modules are automatically discovered
 ```
 </Python>
 
@@ -83,7 +84,7 @@ interface ExampleSchema {
 }
 
 // Create a standalone table named "example_table"
-const exampleTable = new OlapTable<ExampleSchema>("example_table", {
+export const exampleTable = new OlapTable<ExampleSchema>("example_table", {
   orderByFields: ["id", "dateField"], // Optional when using a primary key
   engine: ClickHouseEngines.ReplacingMergeTree,  // Optional: keep only the latest version of each record
 });

--- a/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
@@ -3,7 +3,7 @@ title: TypeScript Moose Lib Reference
 description: TypeScript Moose Lib Reference
 ---
 
-import { LanguageSwitcher, TypeScript, Python } from "@/components";
+import { LanguageSwitcher, TypeScript, Python, ExportRequirement } from "@/components";
 
 # API Reference
 
@@ -46,10 +46,10 @@ interface ApiUtil {
 Creates a ClickHouse table with the schema of type T.
 ```ts
 // Basic usage
-const myTable = new OlapTable<UserProfile>("user_profiles");
+export const myTable = new OlapTable<UserProfile>("user_profiles");
 
 // With configuration
-const myTable = new OlapTable<UserProfile>("user_profiles", {
+export const myConfiguredTable = new OlapTable<UserProfile>("user_profiles", {
   orderByFields: ["id", "timestamp"],
   engine: ClickHouseEngines.ReplacingMergeTree,
 });
@@ -59,16 +59,16 @@ const myTable = new OlapTable<UserProfile>("user_profiles", {
 Creates a Redpanda topic with the schema of type T.
 ```ts
 // Basic usage
-const myStream = new Stream<UserEvent>("user_events");
+export const myStream = new Stream<UserEvent>("user_events");
 
 // With configuration
-const myStream = new Stream<UserEvent>("user_events", {
+export const myConfiguredStream = new Stream<UserEvent>("user_events", {
   parallelism: 3,
   retentionPeriod: 86400 // 1 day in seconds
 });
 
 // Adding transformations
-myStream.addTransform(
+myConfiguredStream.addTransform(
   destinationStream,
   (record) => transformFunction(record)
 );
@@ -78,7 +78,7 @@ myStream.addTransform(
 Creates an HTTP endpoint for ingesting data of type T.
 ```ts
 // Basic usage with destination stream
-const myIngestApi = new IngestApi<UserEvent>("user_events", {
+export const myIngestApi = new IngestApi<UserEvent>("user_events", {
   destination: myUserEventStream
 });
 ```
@@ -87,7 +87,7 @@ const myIngestApi = new IngestApi<UserEvent>("user_events", {
 Creates an HTTP endpoint for querying data with request type T and response type R.
 ```ts
 // Basic usage
-const myApi = new Api<UserQuery, UserProfile[]>(
+export const myApi = new Api<UserQuery, UserProfile[]>(
   "getUserProfiles",
   async (params, { client, sql }) => {
     const result = await client.query.execute(
@@ -102,14 +102,14 @@ const myApi = new Api<UserQuery, UserProfile[]>(
 Combines ingest API, stream, and table creation in a single component.
 ```ts
 // Basic usage
-const pipeline = new IngestPipeline<UserEvent>("user_pipeline", {
+export const pipeline = new IngestPipeline<UserEvent>("user_pipeline", {
   ingest: true,
   stream: true,
   table: true
 });
 
 // With advanced configuration
-const pipeline = new IngestPipeline<UserEvent>("user_pipeline", {
+export const advancedPipeline = new IngestPipeline<UserEvent>("advanced_pipeline", {
   ingest: true,
   stream: { parallelism: 3 },
   table: { 
@@ -123,7 +123,7 @@ const pipeline = new IngestPipeline<UserEvent>("user_pipeline", {
 Creates a materialized view in ClickHouse.
 ```ts
 // Basic usage
-const view = new MaterializedView<UserStatistics>({
+export const view = new MaterializedView<UserStatistics>({
   selectStatement: "SELECT user_id, COUNT(*) as event_count FROM user_events GROUP BY user_id",
   tableName: "user_events",
   materializedViewName: "user_statistics",
@@ -179,7 +179,7 @@ enum ClickHouseEngines {
 A class that represents a single task within a workflow system.
 ```ts
 // No input, no output
-const task1 = new Task<null, void>("task1", {
+export const task1 = new Task<null, void>("task1", {
   run: async () => {
     console.log("No input/output");
   },
@@ -188,7 +188,7 @@ const task1 = new Task<null, void>("task1", {
 });
 
 // With input and output
-const task2 = new Task<InputType, OutputType>("task2", {
+export const task2 = new Task<InputType, OutputType>("task2", {
   run: async (input: InputType) => {
     return process(input);
   },
@@ -230,6 +230,7 @@ const myWorkflow = new Workflow("getData", {
   timeout: "1h",
   retries: 3
 });
+
 ```
 
 ### `WorkflowConfig`
@@ -250,4 +251,23 @@ interface WorkflowConfig {
 }
 ```
 
+---
+
+<ExportRequirement 
+  primitive="Infrastructure Components" 
+  example="export { myTable, myStream, myApi, myWorkflow, myTask, myPipeline, myView }" 
+/>
+
+**Important:** The following components must be exported from your `app/index.ts` file for Moose to detect them:
+
+- `OlapTable` instances
+- `Stream` instances  
+- `IngestApi` instances
+- `Api` instances
+- `IngestPipeline` instances
+- `MaterializedView` instances
+- `Task` instances
+- `Workflow` instances
+
+**Configuration objects and utilities** (like `DeadLetterQueue`, `Key`, `sql`) do not need to be exported as they are used as dependencies of the main components.
 

--- a/apps/framework-docs/src/pages/moose/streaming.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming.mdx
@@ -3,7 +3,7 @@ title: Moose Streaming
 description: Build real-time data pipelines with Redpanda/Kafka streams, transformations, and event processing
 ---
 
-import { Callout, BulletPointsCard, LanguageSwitcher, TypeScript, Python, CTACards, CTACard } from "@/components";
+import { Callout, BulletPointsCard, LanguageSwitcher, TypeScript, Python, CTACards, CTACard, ExportRequirement } from "@/components";
 import { Tabs } from "nextra/components";
 
 # Moose Streaming
@@ -14,6 +14,8 @@ import { Tabs } from "nextra/components";
 The Streaming module provides standalone real-time data processing with Kafka/Redpanda topics. You can use this capability independently to build event-driven architectures, data transformations, and real-time pipelines without requiring other MooseStack components.
 
 ## Basic Usage
+
+<ExportRequirement primitive="Stream" example="export { exampleStream }" />
 
 <TypeScript>
 ```ts filename="Stream.ts" copy
@@ -27,7 +29,7 @@ interface ExampleEvent {
 }
 
 // Create a standalone stream for events
-const exampleStream = new Stream<ExampleEvent>("streaming-topic-name", {
+export const exampleStream = new Stream<ExampleEvent>("streaming-topic-name", {
   // Optional: specify destination table
   destination: new OlapTable<ExampleEvent>("table-name")
 });
@@ -61,6 +63,8 @@ def process_event(event: ExampleEvent):
     # Custom processing logic here
 
 example_stream.add_consumer(process_event)
+
+# No export needed - Python modules are automatically discovered
 ```
 </Python>
 

--- a/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
@@ -261,14 +261,14 @@ interface TransformedData {
 }
 
 // Configure components for raw data ingestion & buffering
-const rawDataStream = new Stream<RawData>("raw_data");
-const rawIngestionStream = new IngestApi<RawData>("raw_data", {
+export const rawDataStream = new Stream<RawData>("raw_data");
+export const rawIngestionStream = new IngestApi<RawData>("raw_data", {
   destination: rawDataStream
 });
 
 // Configure components for transformed data stream & storage
-const transformedTable = new OlapTable<TransformedData>("transformed_data");
-const transformedStream = new Stream<TransformedData>("transformed_stream", {
+export const transformedTable = new OlapTable<TransformedData>("transformed_data");
+export const transformedStream = new Stream<TransformedData>("transformed_stream", {
   destination: transformedTable // Configure the stream <-> table sync
 });
 
@@ -359,7 +359,7 @@ const rawData = new IngestPipeline<RawData>("raw_data", {
 });
 
 // Create an intermediate stream to hold data between transformations (no api or table needed)
-const intermediateStream = new Stream<IntermediateData>("intermediate_stream");
+export const intermediateStream = new Stream<IntermediateData>("intermediate_stream");
 
 // First transformation: double the value and add timestamp
 rawData.stream.addTransform(intermediateStream, (record) => ({
@@ -448,7 +448,7 @@ intermediate_stream.add_transform(destination=final_data.get_stream(), transform
 
 <TypeScript>
 ```typescript filename="StreamConfig.ts"
-const highThroughputStream = new Stream<Data>("high_throughput", {
+export const highThroughputStream = new Stream<Data>("high_throughput", {
   parallelism: 4,              // Process 4 records simultaneously
   retentionPeriod: 86400      // Keep data for 1 day
 });
@@ -475,12 +475,12 @@ Control how Moose manages your stream resources when your code changes. See the 
 import { Stream, LifeCycle } from "@514labs/moose-lib";
 
 // Production stream with external management
-const prodStream = new Stream<Data>("prod_stream", {
+export const prodStream = new Stream<Data>("prod_stream", {
   lifeCycle: LifeCycle.EXTERNALLY_MANAGED
 });
 
 // Development stream with full management
-const devStream = new Stream<Data>("dev_stream", {
+export const devStream = new Stream<Data>("dev_stream", {
   lifeCycle: LifeCycle.FULLY_MANAGED
 });
 ```

--- a/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
@@ -55,7 +55,7 @@ interface RawData {
   value: number;
 }
 
-const rawIngestionStream = new IngestPipeline<RawData>("raw_data", {
+export const rawIngestionStream = new IngestPipeline<RawData>("raw_data", {
   ingest: true, // Creates an ingestion API endpoint at `POST /ingest/raw_data`
   stream: true, // Buffers data between the ingestion API and the database table
   table: true // Creates an OLAP table named `raw_data`
@@ -93,16 +93,16 @@ interface RawData {
   value: number;
 }
 // Create a table for the raw data
-const rawTable = new OlapTable<RawData>("raw_data");
+export const rawTable = new OlapTable<RawData>("raw_data");
 
 // Create a stream for the raw data
-const rawStream = new Stream<RawData>("raw_data", {
+export const rawStream = new Stream<RawData>("raw_data", {
   destination: rawTable // Optional: Specify a destination table for the stream, sets up a process to sync data from the stream to the table
 });
 
 // Create an ingestion API for the raw data
-const rawIngestApi = new IngestApi<RawData>("raw_data" {
-  destination: rawIngestionStream // Configure Moose to write all validated data to the stream
+export const rawIngestApi = new IngestApi<RawData>("raw_data", {
+  destination: rawStream // Configure Moose to write all validated data to the stream
 });
 ```
 </TypeScript>

--- a/apps/framework-docs/src/pages/moose/workflows.mdx
+++ b/apps/framework-docs/src/pages/moose/workflows.mdx
@@ -3,7 +3,7 @@ title: Moose Workflows
 description: Build ETL pipelines, scheduled jobs, and long-running tasks with orchestration
 ---
 
-import { Callout, LanguageSwitcher, BulletPointsCard, TypeScript, Python, CTACards, CTACard } from "@/components";
+import { Callout, LanguageSwitcher, BulletPointsCard, TypeScript, Python, CTACards, CTACard, ExportRequirement } from "@/components";
 import { FileTree } from "nextra/components";
 
 # Moose Workflows
@@ -14,6 +14,8 @@ import { FileTree } from "nextra/components";
 The Workflows module provides standalone task orchestration and automation. You can use this capability independently to build ETL pipelines, run scheduled jobs, trigger background tasks, and manage long-running tasks without requiring other MooseStack components like databases or streams.
 
 ### Basic Usage
+
+<ExportRequirement primitive="Workflow and Task" example="export { myworkflow, task1, task2 }" />
 
 <TypeScript>
 ```typescript filename="DataFlow.ts" copy
@@ -49,6 +51,7 @@ export const task2 = new Task<Bar, void>("task2", {
 export const myworkflow = new Workflow("myworkflow", {
   startingTask: task1
 });
+
 ```
 </TypeScript>
 
@@ -89,6 +92,9 @@ task2 = Task[Bar, None](
 myworkflow = Workflow(
     name="myworkflow",
     config=WorkflowConfig(starting_task=task1)
+)
+
+# No export needed - Python modules are automatically discovered
 ```
 </Python>
 


### PR DESCRIPTION
This pull request updates the Moose framework documentation to clarify and enforce best practices for exporting and importing data components, especially for TypeScript and Python projects. It introduces a new `ExportRequirement` component to highlight export/import requirements, updates code examples to use explicit exports, and improves cross-language guidance throughout the docs.

The most important changes are:

**Documentation improvements for export/import patterns:**

* Added a new `ExportRequirement` component (`export-requirement.tsx`) to visually call out export/import requirements for primitives like tables and APIs in the documentation. This component is now used in key docs pages to clarify the need for explicit exports in TypeScript and imports in Python. [[1]](diffhunk://#diff-81966ba41feffc4bd5d8a21fcc9f5c7828081c8da5d0515c5cd183d1f2353f78R1-R44) [[2]](diffhunk://#diff-dd67cd177efaa38b234383711b12316baf8a1f8b20fbc52ad573bfe96145522dR19) [[3]](diffhunk://#diff-d42e71a92179e7b783d0d2918ba4c42515ffadc66cbab5a26809e134b9dc3666L6-R6) [[4]](diffhunk://#diff-01607e465cdef6b640990012908b28d75c5da6115d0dbbe48f114a3762105e1eL6-R6) [[5]](diffhunk://#diff-a67c98d4bba74a14f33996826c83f074b6286b049f7f340a860411f42eb0b853L6-R6)
* Inserted prominent callouts and usage of the `ExportRequirement` component in the "Moose OLAP", "Moose APIs", and "Quickstart" documentation pages, making the export/import pattern explicit for both TypeScript and Python users. [[1]](diffhunk://#diff-d42e71a92179e7b783d0d2918ba4c42515ffadc66cbab5a26809e134b9dc3666R45-R46) [[2]](diffhunk://#diff-01607e465cdef6b640990012908b28d75c5da6115d0dbbe48f114a3762105e1eL16-R19) [[3]](diffhunk://#diff-804517bbb2ecd91cd4fc282aaa3dd57e0da90d67b0308764d980ae486b64227bR195-R199) [[4]](diffhunk://#diff-804517bbb2ecd91cd4fc282aaa3dd57e0da90d67b0308764d980ae486b64227bR218-R222) [[5]](diffhunk://#diff-1c02061beec898bb68d8eb0b15fc6fd1477590d6963d0dc72dfaa1d05f77ad70R213-R217) [[6]](diffhunk://#diff-1c02061beec898bb68d8eb0b15fc6fd1477590d6963d0dc72dfaa1d05f77ad70R227-R231)

**Code example updates for clarity and correctness:**

* Updated all TypeScript code samples for tables, streams, APIs, and materialized views to use `export const ...` so that Moose can detect these components, and added comments or callouts explaining this requirement. [[1]](diffhunk://#diff-d42e71a92179e7b783d0d2918ba4c42515ffadc66cbab5a26809e134b9dc3666L59-R61) [[2]](diffhunk://#diff-d42e71a92179e7b783d0d2918ba4c42515ffadc66cbab5a26809e134b9dc3666L100-R104) [[3]](diffhunk://#diff-4289c94dcf7965e3939db13e35a88decb68f347376673c8e8d2e44a1c50cdfedL49-R49) [[4]](diffhunk://#diff-6cf0e21852578847d297faba4ffc0345d0c5c47a2df6182718ef569975a2824bL45-R45) [[5]](diffhunk://#diff-01607e465cdef6b640990012908b28d75c5da6115d0dbbe48f114a3762105e1eL37-R29) [[6]](diffhunk://#diff-b4e39ee39b0509f3095b98b4f15fe40bd8b34ab3868e799cbb760d15f67cc399L31-R31) [[7]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L30-R30) [[8]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7L86-R87) [[9]](diffhunk://#diff-a67c98d4bba74a14f33996826c83f074b6286b049f7f340a860411f42eb0b853L49-R52) [[10]](diffhunk://#diff-a67c98d4bba74a14f33996826c83f074b6286b049f7f340a860411f42eb0b853L62-R71) [[11]](diffhunk://#diff-a67c98d4bba74a14f33996826c83f074b6286b049f7f340a860411f42eb0b853L81-R81) [[12]](diffhunk://#diff-a67c98d4bba74a14f33996826c83f074b6286b049f7f340a860411f42eb0b853L90-R90)
* Clarified in Python examples that no explicit export is needed, but all relevant components must be imported in `main.py` for Moose to detect them, and added corresponding comments. [[1]](diffhunk://#diff-d42e71a92179e7b783d0d2918ba4c42515ffadc66cbab5a26809e134b9dc3666R81-R82) [[2]](diffhunk://#diff-d42e71a92179e7b783d0d2918ba4c42515ffadc66cbab5a26809e134b9dc3666R135-R136) [[3]](diffhunk://#diff-01607e465cdef6b640990012908b28d75c5da6115d0dbbe48f114a3762105e1eR45-R58) [[4]](diffhunk://#diff-9d017e382a0fffd1296ba2fd43ae6c3829fe992d16c68d8dea95d01ae9966fc7R48)

**Improved cross-language developer experience:**

* Enhanced the "local development" documentation to provide side-by-side TypeScript and Python guidance on how Moose detects components, using language switchers and clear callouts for both ecosystems. [[1]](diffhunk://#diff-bc6e38f683eda28b0cacac3e822b845103d84da46fed66147904dfb274dee485L73-R83) [[2]](diffhunk://#diff-bc6e38f683eda28b0cacac3e822b845103d84da46fed66147904dfb274dee485L87-R127)

These changes make the documentation more actionable and reduce confusion for developers integrating with Moose, especially around the critical step of exporting or importing root-level data components for hot-reloading and deployment.