### PR TITLE
Added support for multiple kafka broker

### DIFF
--- a/packages/ts-moose-lib/src/moose-runner.ts
+++ b/packages/ts-moose-lib/src/moose-runner.ts
@@ -178,7 +178,7 @@ program
   .description("Run streaming functions")
   .argument("<source-topic>", "Source topic configuration as JSON")
   .argument("<function-file-path>", "Path to the function file")
-  .argument("<broker>", "Kafka broker address")
+  .argument("<broker>", "Kafka broker address(es) - comma-separated for multiple brokers (e.g., 'broker1:9092,broker2:9092')")
   .argument("<max-subscriber-count>", "Maximum number of subscribers")
   .option("--target-topic <target-topic>", "Target topic configuration as JSON")
   .option("--sasl-username <username>", "SASL username")

--- a/packages/ts-moose-lib/src/streaming-functions/runner.ts
+++ b/packages/ts-moose-lib/src/streaming-functions/runner.ts
@@ -199,7 +199,7 @@ export interface StreamingFunctionArgs {
   sourceTopic: TopicConfig;
   targetTopic?: TopicConfig;
   functionFilePath: string;
-  broker: string;
+  broker: string; // Comma-separated list of Kafka broker addresses (e.g., "broker1:9092,broker2:9092")
   maxSubscriberCount: number;
   isDmv2: boolean;
   saslUsername?: string;
@@ -872,7 +872,7 @@ export const runStreamingFunctions = async (
 
       const kafka = new Kafka({
         clientId: processId,
-        brokers: [args.broker],
+        brokers: args.broker.split(','),
         ssl: args.securityProtocol === "SASL_SSL",
         sasl: buildSaslConfig(logger, args),
         retry: {


### PR DESCRIPTION
This pull request updates the handling of Kafka broker addresses in the streaming functions runner to support multiple brokers. The main improvement is allowing users to specify a comma-separated list of broker addresses, which enhances fault tolerance and flexibility when connecting to Kafka clusters.

**Kafka broker configuration improvements:**

* Updated the CLI argument description in `moose-runner.ts` to clarify that the `<broker>` argument can now accept a comma-separated list of Kafka broker addresses.
* Updated the `StreamingFunctionArgs` interface in `runner.ts` to document that the `broker` field is a comma-separated list of broker addresses.
* Modified the Kafka client initialization in `runStreamingFunctions` to split the `broker` string into an array, enabling support for multiple brokers.