### PR TITLE
Olivia/hooks dev server

### DIFF
--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -82,6 +82,7 @@ use std::ops::Deref;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::net::TcpListener;
@@ -142,9 +143,16 @@ pub struct LocalWebserverConfig {
     /// Maximum request body size in bytes (default: 10MB)
     #[serde(default = "default_max_request_body_size")]
     pub max_request_body_size: usize,
-    /// Script to run after dev server is ready
-    #[serde(default)]
-    pub post_dev_server_ready_script: Option<String>,
+    /// Script to run after dev server reload completes for code/infrastructure changes
+    #[serde(
+        default,
+        alias = "after_change_script",
+        alias = "post_dev_server_ready_script"
+    )]
+    pub after_dev_server_reload_script: Option<String>,
+    /// Script to run once when the dev server first starts (never repeats in this process)
+    #[serde(default, alias = "post_dev_server_start_script")]
+    pub on_start_script_once: Option<String>,
 }
 
 pub fn default_proxy_port() -> u16 {
@@ -176,8 +184,8 @@ impl LocalWebserverConfig {
         })
     }
 
-    pub async fn run_dev_ready_script(&self) {
-        if let Some(ref script) = self.post_dev_server_ready_script {
+    pub async fn run_after_dev_server_reload_script(&self) {
+        if let Some(ref script) = self.after_dev_server_reload_script {
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
 
             let child = Command::new(shell)
@@ -194,7 +202,7 @@ impl LocalWebserverConfig {
                             show_message!(MessageType::Success, {
                                 Message {
                                     action: "Ran".to_string(),
-                                    details: "script for dev server ready".to_string(),
+                                    details: "script after dev server reload".to_string(),
                                 }
                             });
                         }
@@ -202,7 +210,7 @@ impl LocalWebserverConfig {
                             show_message!(MessageType::Error, {
                                 Message {
                                     action: "Fail".to_string(),
-                                    details: format!("script for dev server ready: {status}"),
+                                    details: format!("script after dev server reload: {status}"),
                                 }
                             });
                         }
@@ -210,7 +218,9 @@ impl LocalWebserverConfig {
                             show_message!(MessageType::Error, {
                                 Message {
                                     action: "Failed".to_string(),
-                                    details: format!("to wait for script for dev server\n{e:?}"),
+                                    details: format!(
+                                        "to wait for script after dev server reload\n{e:?}"
+                                    ),
                                 }
                             });
                         }
@@ -220,7 +230,70 @@ impl LocalWebserverConfig {
                     show_message!(MessageType::Error, {
                         Message {
                             action: "Failed".to_string(),
-                            details: format!("to spawn post_dev_server_ready_script:\n{e:?}"),
+                            details: format!("to spawn after_dev_server_reload_script:\n{e:?}"),
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    pub async fn run_dev_start_script_once(&self) {
+        static START_SCRIPT_RAN: AtomicBool = AtomicBool::new(false);
+
+        if START_SCRIPT_RAN
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        if let Some(ref script) = self.on_start_script_once {
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+
+            let child = Command::new(shell)
+                .arg("-c")
+                .arg(script)
+                .stdin(Stdio::null())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn();
+            match child {
+                Ok(mut child) => {
+                    match child.wait().await {
+                        Ok(status) if status.success() => {
+                            show_message!(MessageType::Success, {
+                                Message {
+                                    action: "Ran".to_string(),
+                                    details: "script for dev server start".to_string(),
+                                }
+                            });
+                        }
+                        Ok(status) => {
+                            show_message!(MessageType::Error, {
+                                Message {
+                                    action: "Fail".to_string(),
+                                    details: format!("script for dev server start: {status}"),
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            show_message!(MessageType::Error, {
+                                Message {
+                                    action: "Failed".to_string(),
+                                    details: format!(
+                                        "to wait for script for dev server start\n{e:?}"
+                                    ),
+                                }
+                            });
+                        }
+                    };
+                }
+                Err(e) => {
+                    show_message!(MessageType::Error, {
+                        Message {
+                            action: "Failed".to_string(),
+                            details: format!("to spawn on_start_script_once:\n{e:?}"),
                         }
                     });
                 }
@@ -238,7 +311,8 @@ impl Default for LocalWebserverConfig {
             proxy_port: default_proxy_port(),
             path_prefix: None,
             max_request_body_size: default_max_request_body_size(),
-            post_dev_server_ready_script: None,
+            after_dev_server_reload_script: None,
+            on_start_script_once: None,
         }
     }
 }
@@ -1676,6 +1750,17 @@ impl Webserver {
         );
 
         if !project.is_production {
+            // Fire once-only startup script as soon as server starts
+            {
+                let project_clone = project.clone();
+                tokio::spawn(async move {
+                    project_clone
+                        .http_server_config
+                        .run_dev_start_script_once()
+                        .await;
+                });
+            }
+
             show_message!(
                 MessageType::Highlight,
                 Message {
@@ -1684,13 +1769,7 @@ impl Webserver {
                 }
             );
 
-            let project_clone = project.clone();
-            tokio::spawn(async move {
-                project_clone
-                    .http_server_config
-                    .run_dev_ready_script()
-                    .await;
-            });
+            // Do not run after_dev_server_reload_script at initial start; it's intended for reloads only.
         }
 
         let mut sigterm =

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -146,13 +146,13 @@ pub struct LocalWebserverConfig {
     /// Script to run after dev server reload completes for code/infrastructure changes
     #[serde(
         default,
-        alias = "after_change_script",
+        alias = "on_change_script",
         alias = "post_dev_server_ready_script"
     )]
-    pub after_dev_server_reload_script: Option<String>,
+    pub on_reload_complete_script: Option<String>,
     /// Script to run once when the dev server first starts (never repeats in this process)
     #[serde(default, alias = "post_dev_server_start_script")]
-    pub on_start_script_once: Option<String>,
+    pub on_first_start_script: Option<String>,
 }
 
 pub fn default_proxy_port() -> u16 {
@@ -185,7 +185,7 @@ impl LocalWebserverConfig {
     }
 
     pub async fn run_after_dev_server_reload_script(&self) {
-        if let Some(ref script) = self.after_dev_server_reload_script {
+        if let Some(ref script) = self.on_reload_complete_script {
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
 
             let child = Command::new(shell)
@@ -230,7 +230,7 @@ impl LocalWebserverConfig {
                     show_message!(MessageType::Error, {
                         Message {
                             action: "Failed".to_string(),
-                            details: format!("to spawn after_dev_server_reload_script:\n{e:?}"),
+                            details: format!("to spawn on_reload_complete_script:\n{e:?}"),
                         }
                     });
                 }
@@ -248,7 +248,7 @@ impl LocalWebserverConfig {
             return;
         }
 
-        if let Some(ref script) = self.on_start_script_once {
+        if let Some(ref script) = self.on_first_start_script {
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
 
             let child = Command::new(shell)
@@ -293,7 +293,7 @@ impl LocalWebserverConfig {
                     show_message!(MessageType::Error, {
                         Message {
                             action: "Failed".to_string(),
-                            details: format!("to spawn on_start_script_once:\n{e:?}"),
+                            details: format!("to spawn on_first_start_script:\n{e:?}"),
                         }
                     });
                 }
@@ -311,8 +311,8 @@ impl Default for LocalWebserverConfig {
             proxy_port: default_proxy_port(),
             path_prefix: None,
             max_request_body_size: default_max_request_body_size(),
-            after_dev_server_reload_script: None,
-            on_start_script_once: None,
+            on_reload_complete_script: None,
+            on_first_start_script: None,
         }
     }
 }

--- a/apps/framework-cli/src/cli/watcher.rs
+++ b/apps/framework-cli/src/cli/watcher.rs
@@ -229,7 +229,10 @@ async fn watch(
                     .await;
                     match result {
                         Ok(()) => {
-                            project.http_server_config.run_dev_ready_script().await;
+                            project
+                                .http_server_config
+                                .run_after_dev_server_reload_script()
+                                .await;
                         }
                         Err(e) => {
                             show_message!(MessageType::Error, {

--- a/apps/framework-docs/src/pages/moose/apis/openapi-sdk.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/openapi-sdk.mdx
@@ -69,6 +69,60 @@ openapi-generator-cli generate \
   -o ./generated-client
 ```
 
+## Automate SDK Generation on Reload
+
+Keep your SDKs continuously up to date by configuring Moose to regenerate them automatically after each dev server reload. Use the new `on_reload_complete_script` hook in your `moose.config.toml`.
+
+### Configure hooks in `moose.config.toml`
+
+```toml filename="moose.config.toml" copy
+[http_server_config]
+# Runs once when the dev server starts (good place to ensure tools are installed)
+on_first_start_script = "command -v openapi-generator-cli >/dev/null 2>&1 || npm i -g @openapitools/openapi-generator-cli"
+
+# Runs after each dev server reload (infra or code changes fully applied)
+# Regenerate SDKs for multiple targets as needed
+on_reload_complete_script = "\
+  openapi-generator-cli generate -i .moose/openapi.yaml -g typescript-fetch -o ./generated/ts && \
+  openapi-generator-cli generate -i .moose/openapi.yaml -g python -o ./generated/python\
+"
+```
+
+Notes:
+- The script runs in your project root using your `$SHELL` (falls back to `/bin/sh`).
+- Paths like `.moose/openapi.yaml` and `./generated/...` are relative to the project root.
+- Combine multiple generators with `&&` (as shown) or split into a shell script if preferred.
+
+### Example: TypeScript on reload
+
+```toml filename="moose.config.toml" copy
+[http_server]
+on_reload_complete_script = "openapi-generator-cli generate -i .moose/openapi.yaml -g typescript-fetch -o ./generated/ts"
+```
+
+### Example: Python on reload
+
+```toml filename="moose.config.toml" copy
+[http_server]
+on_reload_complete_script = "openapi-generator-cli generate -i .moose/openapi.yaml -g python -o ./generated/python"
+```
+
+### One-time setup hook (optional)
+
+Use `on_first_start_script` for one-time setup, like installing the generator or cleaning the output directory:
+
+```toml filename="moose.config.toml" copy
+[http_server]
+on_first_start_script = "\
+  (command -v openapi-generator-cli >/dev/null 2>&1 || npm i -g @openapitools/openapi-generator-cli) && \
+  rm -rf ./generated/ts ./generated/python\
+"
+```
+
+<Callout type="info">
+These hooks only affect local development (`moose dev`). The reload hook runs after Moose finishes applying your changes, ensuring `.moose/openapi.yaml` is fresh before regeneration.
+</Callout>
+
 ## Integration Examples
 
 ### TypeScript Integration


### PR DESCRIPTION
This pull request refactors and enhances the dev server scripting functionality in the local webserver CLI. It introduces clearer separation between scripts that run once at initial server start and those that run after reloads due to code or infrastructure changes. The configuration is updated to support these changes, and error/success messages are clarified for better feedback.

**Dev server scripting improvements:**

* Replaced the single `post_dev_server_ready_script` config option with two distinct options in `LocalWebserverConfig`: `on_first_start_script` (runs once at initial start) and `on_reload_complete_script` (runs after reloads). Aliases are added for backward compatibility. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL145-R155) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL241-R315)
* Added a new method, `run_dev_start_script_once`, which ensures the startup script only runs once per process using an `AtomicBool`.
* Updated the dev server startup logic to run the new startup script only at initial start, and clarified that the reload script is not run at startup. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aR1753-R1763) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL1687-R1772)
* Changed watcher logic to call the new reload script method after reloads, replacing the previous ready script call.

**Error and success messaging:**

* Updated success and error messages throughout to clearly indicate whether they relate to the startup or reload script, improving developer feedback. [[1]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL197-R223) [[2]](diffhunk://#diff-fee871a911a583459e462af9d8c682e0f98be4006d2866ce74821b05ee304a9aL223-R296)