### PR TITLE
Refactor engine configuration architecture

### DIFF
--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -2519,6 +2519,7 @@ mod diff_tests {
     use super::*;
     use crate::framework::core::infrastructure::table::{Column, ColumnType, FloatType, IntType};
     use crate::framework::versions::Version;
+    use crate::infrastructure::olap::clickhouse::queries::ClickhouseEngine;
     use serde_json::Value as JsonValue;
 
     // Helper function to create a basic test table
@@ -2791,8 +2792,8 @@ mod diff_tests {
         let mut before = create_test_table("test", "1.0");
         let mut after = create_test_table("test", "1.0");
 
-        before.engine = Some("MergeTree".to_string());
-        after.engine = Some("ReplacingMergeTree".to_string());
+        before.engine = Some(ClickhouseEngine::MergeTree);
+        after.engine = Some(ClickhouseEngine::ReplacingMergeTree);
 
         let mut changes = Vec::new();
         InfrastructureMap::diff_tables(
@@ -2808,8 +2809,11 @@ mod diff_tests {
                 after: a,
                 ..
             }) => {
-                assert_eq!(b.engine.as_deref(), Some("MergeTree"));
-                assert_eq!(a.engine.as_deref(), Some("ReplacingMergeTree"));
+                assert_eq!(b.engine.as_ref(), Some(&ClickhouseEngine::MergeTree));
+                assert_eq!(
+                    a.engine.as_ref(),
+                    Some(&ClickhouseEngine::ReplacingMergeTree)
+                );
             }
             _ => panic!("Expected Updated change with engine modification"),
         }


### PR DESCRIPTION
- Move from string-based to typed ClickhouseEngine enum in Table struct
- Add generic engine configuration framework foundation
- Update protobuf conversion logic to handle typed engines
- Add infrastructure for future engine-specific settings
- Maintain backward compatibility with existing table configurations

Note: This creates foundation for engine-specific configurations while acknowledging the leaky abstraction that should be addressed in future PRs