### PR TITLE
mitchell/chore-nested: api routes

### DIFF
--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -547,12 +547,20 @@ impl PartialInfrastructureMap {
                         format!("ingest/{}", custom_path)
                     };
 
-                    // Append version if specified
+                    // Append version if specified and not already in the path
                     if let Some(version) = &partial_api.version {
-                        if !path_str.ends_with('/') {
-                            path_str.push('/');
+                        // Check if the path already ends with the version
+                        let path_ends_with_version = path_str.ends_with(&format!("/{}", version))
+                            || path_str.ends_with(version) && path_str.len() == version.len()
+                            || path_str.ends_with(version)
+                                && path_str.chars().rev().nth(version.len()) == Some('/');
+
+                        if !path_ends_with_version {
+                            if !path_str.ends_with('/') {
+                                path_str.push('/');
+                            }
+                            path_str.push_str(version);
                         }
-                        path_str.push_str(version);
                     }
 
                     PathBuf::from(path_str)
@@ -599,13 +607,21 @@ impl PartialInfrastructureMap {
                     output_schema: partial_api.response_schema.clone(),
                 },
                 path: if let Some(custom_path) = &partial_api.path {
-                    // Use custom path if provided, and append version if specified
+                    // Use custom path if provided, and append version if specified and not already in the path
                     let mut path_str = custom_path.clone();
                     if let Some(version) = &partial_api.version {
-                        if !path_str.ends_with('/') {
-                            path_str.push('/');
+                        // Check if the path already ends with the version
+                        let path_ends_with_version = path_str.ends_with(&format!("/{}", version))
+                            || path_str.ends_with(version) && path_str.len() == version.len()
+                            || path_str.ends_with(version)
+                                && path_str.chars().rev().nth(version.len()) == Some('/');
+
+                        if !path_ends_with_version {
+                            if !path_str.ends_with('/') {
+                                path_str.push('/');
+                            }
+                            path_str.push_str(version);
                         }
-                        path_str.push_str(version);
                     }
                     PathBuf::from(path_str)
                 } else {

--- a/apps/framework-cli/src/framework/python/wrappers/consumption_runner.py
+++ b/apps/framework-cli/src/framework/python/wrappers/consumption_runner.py
@@ -104,7 +104,10 @@ def handler_with_client(moose_client):
                               str(size)))
         def do_GET(self):
             parsed_path = urlparse(self.path)
-            path_parts = parsed_path.path.lstrip('/').rstrip('/').split('/')
+            full_path = parsed_path.path.lstrip('/').rstrip('/')
+            path_parts = full_path.split('/')
+            
+            # For backward compatibility, keep the old parsing logic
             module_name = path_parts[0]
             version_from_path = "/".join(path_parts[1:]) if len(path_parts) > 1 else None
 
@@ -128,13 +131,19 @@ def handler_with_client(moose_client):
                 query_params = parse_qs(parsed_path.query)
 
                 if is_dmv2:
-                    # Use alias-aware lookup: unversioned name resolves to explicit unversioned
-                    # or the sole versioned API if exactly one exists
-                    user_api = (
-                        get_api(f"{module_name}:{version_from_path}")
-                        if version_from_path
-                        else get_api(module_name)
-                    )
+                    # First try to look up by the full path (for custom paths)
+                    user_api = get_api(full_path)
+                    
+                    # If not found by path, fall back to name:version lookup
+                    if user_api is None:
+                        # Use alias-aware lookup: unversioned name resolves to explicit unversioned
+                        # or the sole versioned API if exactly one exists
+                        user_api = (
+                            get_api(f"{module_name}:{version_from_path}")
+                            if version_from_path
+                            else get_api(module_name)
+                        )
+                    
                     if user_api is not None:
                         query_fields = convert_pydantic_definition(user_api.model_type)
                         try:

--- a/packages/py-moose-lib/moose_lib/dmv2/_registry.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/_registry.py
@@ -13,5 +13,7 @@ _ingest_apis: Dict[str, Any] = {}
 _apis: Dict[str, Any] = {}
 # Alias map for O(1) fallback of sole versioned APIs: base name -> handler
 _api_name_aliases: Dict[str, Any] = {}
+# Map from custom paths to API instances for path-based lookup
+_api_path_map: Dict[str, Any] = {}
 _sql_resources: Dict[str, Any] = {}
-_workflows: Dict[str, Any] = {} 
+_workflows: Dict[str, Any] = {}

--- a/packages/py-moose-lib/moose_lib/dmv2/ingest_api.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/ingest_api.py
@@ -17,9 +17,11 @@ class IngestConfig(BaseModel):
 
     Attributes:
         version: Optional version string.
+        path: Optional custom path for the ingestion endpoint.
         metadata: Optional metadata for the ingestion point.
     """
     version: Optional[str] = None
+    path: Optional[str] = None
     metadata: Optional[dict] = None
 
 @dataclasses.dataclass
@@ -28,12 +30,15 @@ class IngestConfigWithDestination[T: BaseModel]:
 
     Attributes:
         destination: The `Stream` where ingested data will be sent.
+        dead_letter_queue: Optional dead letter queue for failed messages.
         version: Optional version string.
+        path: Optional custom path for the ingestion endpoint.
         metadata: Optional metadata for the ingestion configuration.
     """
     destination: Stream[T]
     dead_letter_queue: Optional[DeadLetterQueue[T]] = None
     version: Optional[str] = None
+    path: Optional[str] = None
     metadata: Optional[dict] = None
 
 class IngestApi(TypedMooseResource, Generic[T]):

--- a/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
@@ -24,7 +24,9 @@ class IngestPipelineConfig(BaseModel):
         table: Configuration for the OLAP table component.
         stream: Configuration for the stream component.
         ingest: Configuration for the ingest API component.
+        dead_letter_queue: Configuration for the dead letter queue.
         version: Optional version string applied to all created components.
+        path: Optional custom path for the ingestion API endpoint.
         metadata: Optional metadata for the ingestion pipeline.
         life_cycle: Determines how changes in code will propagate to the resources.
     """
@@ -33,6 +35,7 @@ class IngestPipelineConfig(BaseModel):
     ingest: bool | IngestConfig = True
     dead_letter_queue: bool | StreamConfig = True
     version: Optional[str] = None
+    path: Optional[str] = None
     metadata: Optional[dict] = None
     life_cycle: Optional[LifeCycle] = None
 
@@ -154,6 +157,8 @@ class IngestPipeline(TypedMooseResource, Generic[T]):
             ingest_config_dict["destination"] = self.stream
             if config.version:
                 ingest_config_dict["version"] = config.version
+            if config.path:
+                ingest_config_dict["path"] = config.path
             if self.dead_letter_queue:
                 ingest_config_dict["dead_letter_queue"] = self.dead_letter_queue
             ingest_config_dict["metadata"] = ingest_metadata

--- a/packages/py-moose-lib/moose_lib/dmv2/registry.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/registry.py
@@ -19,6 +19,7 @@ from ._registry import (
     _sql_resources,
     _workflows,
     _api_name_aliases,
+    _api_path_map,
 )
 
 def get_tables() -> Dict[str, OlapTable]:
@@ -50,11 +51,25 @@ def get_apis() -> Dict[str, Api]:
     return _apis
 
 def get_api(name: str) -> Optional[Api]:
-    """Get a registered API by name.
+    """Get a registered API by name or path.
 
-    Supports unversioned lookup by name via alias map when only a single versioned API exists.
+    Supports:
+    - Direct lookup by name:version
+    - Unversioned lookup by name via alias map when only a single versioned API exists
+    - Lookup by custom path (if configured)
     """
-    return _apis.get(name) or _api_name_aliases.get(name)
+    # Try direct lookup first
+    api = _apis.get(name)
+    if api:
+        return api
+    
+    # Try alias lookup
+    api = _api_name_aliases.get(name)
+    if api:
+        return api
+    
+    # Try path-based lookup
+    return _api_path_map.get(name)
 
 def get_sql_resources() -> Dict[str, SqlResource]:
     """Get all registered SQL resources."""

--- a/packages/ts-moose-lib/src/consumption-apis/runner.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/runner.ts
@@ -139,24 +139,40 @@ const apiHandler = async (
       if (userFuncModule === undefined) {
         if (isDmv2) {
           let apiName = fileName.replace(/^\/+|\/+$/g, "");
-          let version = url.searchParams.get("version");
+          let version: string | null = null;
 
-          // Check if version is in the path (e.g., /bar/1)
-          if (!version && apiName.includes("/")) {
-            const pathParts = apiName.split("/");
-            if (pathParts.length >= 2) {
-              apiName = pathParts[0];
-              version = pathParts.slice(1).join("/");
+          // First, try to find the API by the full path (for custom paths)
+          userFuncModule = apis.get(apiName);
+
+          if (!userFuncModule) {
+            // Fall back to the old name:version parsing
+            version = url.searchParams.get("version");
+
+            // Check if version is in the path (e.g., /bar/1)
+            if (!version && apiName.includes("/")) {
+              const pathParts = apiName.split("/");
+              if (pathParts.length >= 2) {
+                // Try the full path first (it might be a custom path)
+                userFuncModule = apis.get(apiName);
+                if (!userFuncModule) {
+                  // If not found, treat it as name/version
+                  apiName = pathParts[0];
+                  version = pathParts.slice(1).join("/");
+                }
+              }
+            }
+
+            // Only do versioned lookup if we still haven't found it
+            if (!userFuncModule) {
+              if (version) {
+                const versionedKey = `${apiName}:${version}`;
+                userFuncModule = apis.get(versionedKey);
+              } else {
+                userFuncModule = apis.get(apiName);
+              }
             }
           }
 
-          // Try versioned lookup first if version is available; otherwise rely on aliasing
-          if (version) {
-            const versionedKey = `${apiName}:${version}`;
-            userFuncModule = apis.get(versionedKey);
-          } else {
-            userFuncModule = apis.get(apiName);
-          }
           if (!userFuncModule) {
             const availableApis = Array.from(apis.keys()).map((key) =>
               key.replace(":", "/"),

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -123,6 +123,8 @@ interface IngestApiJson {
   deadLetterQueue?: string;
   /** Optional version string for the API configuration. */
   version?: string;
+  /** Optional custom path for the ingestion endpoint. */
+  path?: string;
   /** Optional description for the API. */
   metadata?: { description?: string };
 }
@@ -139,6 +141,8 @@ interface ApiJson {
   responseSchema: IJsonSchemaCollection.IV3_1;
   /** Optional version string for the API configuration. */
   version?: string;
+  /** Optional custom path for the API endpoint. */
+  path?: string;
   /** Optional description for the API. */
   metadata?: { description?: string };
 }
@@ -268,6 +272,7 @@ export const toInfraMap = (registry: typeof moose_internal) => {
       name: api.name,
       columns: api.columnArray,
       version: api.config.version,
+      path: api.config.path,
       writeTo: {
         kind: "stream",
         name: api.config.destination.name,
@@ -285,6 +290,7 @@ export const toInfraMap = (registry: typeof moose_internal) => {
       queryParams: api.columnArray,
       responseSchema: api.responseSchema,
       version: api.config.version,
+      path: api.config.path,
       metadata: api.metadata,
     };
   });

--- a/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/consumptionApi.ts
@@ -87,11 +87,26 @@ export class Api<T, R = any> extends TypedBase<T, ApiConfig<T>> {
 
     // Also register by custom path if provided
     if (config?.path) {
+      // Check for collision with existing keys
+      if (apis.has(config.path)) {
+        const existing = apis.get(config.path)!;
+        throw new Error(
+          `Cannot register API "${name}" with custom path "${config.path}" - this path is already used by API "${existing.name}"`,
+        );
+      }
       // Register with just the path
       apis.set(config.path, this);
+
       // If versioned, also register with path/version
       if (config.version) {
-        apis.set(`${config.path}/${config.version}`, this);
+        const versionedPath = `${config.path}/${config.version}`;
+        if (apis.has(versionedPath)) {
+          const existing = apis.get(versionedPath)!;
+          throw new Error(
+            `Cannot register API "${name}" with path "${versionedPath}" - this path is already used by API "${existing.name}"`,
+          );
+        }
+        apis.set(versionedPath, this);
       }
     }
   }

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestApi.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestApi.ts
@@ -18,6 +18,10 @@ export interface IngestConfig<T> {
    * An optional version string for this configuration.
    */
   version?: string;
+  /**
+   * An optional custom path for the ingestion endpoint.
+   */
+  path?: string;
   metadata?: { description?: string };
 }
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -91,6 +91,14 @@ export type IngestPipelineConfig<T> = {
   version?: string;
 
   /**
+   * An optional custom path for the ingestion API endpoint.
+   * This will be used as the HTTP path for the ingest API if one is created.
+   *
+   * @example "pipelines/analytics", "data/events"
+   */
+  path?: string;
+
+  /**
    * Optional metadata for the pipeline.
    */
   metadata?: {
@@ -266,6 +274,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
         deadLetterQueue: this.deadLetterQueue,
         ...(typeof config.ingest === "object" ? config.ingest : {}),
         ...(config.version && { version: config.version }),
+        ...(config.path && { path: config.path }),
       };
       this.ingestApi = new IngestApi(
         name,


### PR DESCRIPTION
**chore: fixed api versioning bug**



**chore: solve api registation bug**
it was possible to overwrite existing apis. now it is not



**chore: added python and typescript support for nested paths**



**chore: added handling for custom paths in the web server**
allows users to define nested paths for apis