### PR TITLE
Enable docker in cursor background agent

### DIFF
--- a/.cursor/DOCKER_SETUP.md
+++ b/.cursor/DOCKER_SETUP.md
@@ -1,0 +1,130 @@
+# Docker-in-Docker Setup for Cursor Background Agents
+
+This document describes the Docker-in-Docker (DinD) configuration for running Moose in Cursor's background agent environments.
+
+## Overview
+
+Moose requires Docker to run its services (ClickHouse, Redis, etc.) via Docker Compose. Cursor's background agents don't have Docker running by default, which prevents Moose from functioning. This setup enables Docker within the agent environment.
+
+## Configuration Files
+
+### `.cursor/Dockerfile`
+The custom Dockerfile that builds the agent environment with Docker support:
+
+- **Base Image**: Ubuntu 24.04 LTS
+- **Docker Installation**: Docker Engine, CLI, Containerd, and Docker Compose plugin
+- **User Permissions**: `ubuntu` user added to `docker` group with passwordless sudo
+- **iptables Configuration**: Switched to legacy mode for Docker compatibility
+- **Volume**: `/var/lib/docker` declared for Docker data persistence
+
+### `.cursor/environment.json`
+The Cursor environment configuration:
+
+```json
+{
+  "build": {
+    "context": "..",
+    "dockerfile": ".cursor/Dockerfile"
+  },
+  "start": "sudo service docker start && sleep 2 && docker info > /dev/null 2>&1 && echo 'Docker started successfully' || echo 'Docker startup may have issues'",
+  "install": "echo 'Installing Moose dependencies...' && pnpm install"
+}
+```
+
+## Key Features
+
+### 1. Docker Engine Installation
+- Installs Docker CE from official Docker repository
+- Includes Docker Compose plugin for `docker compose` commands
+- Configures proper GPG keys and repository sources
+
+### 2. User Permissions
+- Creates `docker` group and adds `ubuntu` user
+- Grants passwordless sudo access to `ubuntu` user
+- Enables Docker commands without root privileges
+
+### 3. iptables Legacy Mode
+- Switches from nftables to legacy iptables
+- Resolves Docker networking issues in containerized environments
+- Ensures Docker can manage firewall rules properly
+
+### 4. Automatic Docker Startup
+- Docker daemon starts automatically when agent launches
+- Includes verification to confirm Docker is running
+- Provides feedback on startup success/failure
+
+## Testing the Setup
+
+Run the test script to verify Docker functionality:
+
+```bash
+./.cursor/test-docker.sh
+```
+
+This script tests:
+- Docker daemon status
+- iptables configuration
+- Basic Docker functionality (pull, run containers)
+- Docker networking (port mapping)
+- Docker Compose availability
+- User permissions
+
+## Usage with Moose
+
+Once the environment is configured:
+
+1. **Start a Background Agent**: Use Cursor's background agent feature
+2. **Verify Docker**: Run `docker info` to confirm Docker is running
+3. **Run Moose**: Execute your Moose commands (e.g., `moose up`)
+4. **Check Services**: Use `docker ps` to see running containers
+
+## Troubleshooting
+
+### Docker Daemon Won't Start
+- Check if iptables is in legacy mode: `iptables --version`
+- Verify user permissions: `groups` should include `docker`
+- Check sudo access: `sudo -n true` should succeed
+
+### Networking Issues
+- Test with: `docker run -p 8080:80 nginx:alpine`
+- Check if containers can reach each other
+- Verify port mapping works with `curl localhost:8080`
+
+### Permission Errors
+- Ensure user is in docker group: `sudo usermod -aG docker ubuntu`
+- Check sudoers configuration: `sudo cat /etc/sudoers | grep ubuntu`
+
+## Limitations
+
+- **Performance**: Docker-in-Docker adds overhead due to nested virtualization
+- **Networking**: Some advanced networking features may be limited
+- **Storage**: Docker data may be ephemeral depending on Cursor's snapshot behavior
+- **Security**: This setup prioritizes functionality over strict isolation
+
+## Fallback Options
+
+If standard Docker networking fails, you can try:
+
+1. **Disable iptables**: Start Docker with `--iptables=false`
+2. **Host networking**: Use `--network=host` for containers
+3. **No networking**: Use `--network=none` for isolated containers
+
+## Maintenance
+
+- **Updates**: Docker version is pinned to the latest stable
+- **Dependencies**: All packages are installed in the Dockerfile
+- **Configuration**: Environment settings are in `.cursor/environment.json`
+
+## Support
+
+For issues with this setup:
+1. Check the test script output
+2. Review Cursor's background agent documentation
+3. Consult Docker-in-Docker troubleshooting guides
+4. Contact the development team
+
+## References
+
+- [Cursor Background Agents Documentation](https://cursor.sh/docs)
+- [Docker-in-Docker Best Practices](https://docs.docker.com/engine/security/rootless/)
+- [iptables Legacy Mode](https://wiki.nftables.org/wiki-nftables/index.php/Moving_from_iptables_to_nftables)

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -32,6 +32,21 @@ RUN apt-get update -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=fa
     apt-transport-https \
     software-properties-common \
     sudo \
+    iptables \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Docker's official GPG key and repository
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
+# Install Docker Engine (docker-ce), CLI, Containerd, and Docker Compose plugin
+RUN apt-get update -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false && apt-get install -y --no-install-recommends \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20.x
@@ -64,6 +79,15 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # Set up PATH environment variables for consistent access in all contexts
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# Create docker group and add the default 'ubuntu' user to both docker and sudo groups
+RUN groupadd -f docker && \
+    usermod -aG docker,sudo ubuntu && \
+    echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Switch iptables to legacy mode for Docker compatibility
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
 # Verify installations
 RUN node --version \
     && npm --version \
@@ -73,10 +97,17 @@ RUN node --version \
     && protoc --version \
     && maturin --version \
     && rustc --version \
-    && cargo --version
+    && cargo --version \
+    && docker --version
 
 # Set working directory
 WORKDIR /workspace
+
+# Switch to ubuntu user for the running environment
+USER ubuntu
+
+# Declare Docker data volume
+VOLUME /var/lib/docker
 
 # Copy and run verification script
 COPY scripts/verify-environment.sh /tmp/verify-environment.sh

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "context": "..",
-    "dockerfile": "Dockerfile"
+    "dockerfile": ".cursor/Dockerfile"
   },
-  "start": "sudo service docker start"
+  "start": "sudo service docker start && sleep 2 && docker info > /dev/null 2>&1 && echo 'Docker started successfully' || echo 'Docker startup may have issues'",
+  "install": "echo 'Installing Moose dependencies...' && pnpm install"
 }

--- a/.cursor/test-docker.sh
+++ b/.cursor/test-docker.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Docker-in-Docker Test Script for Cursor Background Agents
+# This script tests the Docker setup in the Cursor agent environment
+
+set -e
+
+echo "=== Docker-in-Docker Test for Cursor Background Agents ==="
+echo "Testing Docker functionality in the agent environment..."
+echo
+
+# Test 1: Check if Docker daemon is running
+echo "1. Checking Docker daemon status..."
+if docker info > /dev/null 2>&1; then
+    echo "✅ Docker daemon is running"
+    docker version
+else
+    echo "❌ Docker daemon is not running"
+    echo "Attempting to start Docker daemon..."
+    sudo service docker start
+    sleep 3
+    if docker info > /dev/null 2>&1; then
+        echo "✅ Docker daemon started successfully"
+    else
+        echo "❌ Failed to start Docker daemon"
+        echo "Checking Docker service status:"
+        sudo service docker status
+        exit 1
+    fi
+fi
+echo
+
+# Test 2: Check iptables configuration
+echo "2. Checking iptables configuration..."
+if iptables --version | grep -q "legacy"; then
+    echo "✅ iptables is using legacy mode"
+else
+    echo "⚠️  iptables is not in legacy mode"
+    echo "Current iptables version:"
+    iptables --version
+fi
+echo
+
+# Test 3: Test basic Docker functionality
+echo "3. Testing basic Docker functionality..."
+echo "Pulling hello-world image..."
+if docker pull hello-world:latest > /dev/null 2>&1; then
+    echo "✅ Successfully pulled hello-world image"
+else
+    echo "❌ Failed to pull hello-world image"
+    exit 1
+fi
+
+echo "Running hello-world container..."
+if docker run --rm hello-world:latest > /dev/null 2>&1; then
+    echo "✅ Successfully ran hello-world container"
+else
+    echo "❌ Failed to run hello-world container"
+    exit 1
+fi
+echo
+
+# Test 4: Test Docker networking
+echo "4. Testing Docker networking..."
+echo "Starting nginx container on port 8080..."
+if docker run -d --name test-nginx -p 8080:80 nginx:alpine > /dev/null 2>&1; then
+    echo "✅ Successfully started nginx container"
+    
+    # Wait a moment for nginx to start
+    sleep 2
+    
+    # Test if we can reach the container
+    if curl -s http://localhost:8080 > /dev/null 2>&1; then
+        echo "✅ Successfully connected to nginx container via localhost:8080"
+    else
+        echo "⚠️  Could not connect to nginx container (networking may be limited)"
+    fi
+    
+    # Clean up
+    docker stop test-nginx > /dev/null 2>&1
+    docker rm test-nginx > /dev/null 2>&1
+    echo "✅ Cleaned up test container"
+else
+    echo "❌ Failed to start nginx container"
+fi
+echo
+
+# Test 5: Test Docker Compose
+echo "5. Testing Docker Compose..."
+if docker compose version > /dev/null 2>&1; then
+    echo "✅ Docker Compose is available"
+    docker compose version
+else
+    echo "❌ Docker Compose is not available"
+fi
+echo
+
+# Test 6: Check user permissions
+echo "6. Checking user permissions..."
+if groups | grep -q docker; then
+    echo "✅ User is in docker group"
+else
+    echo "⚠️  User is not in docker group"
+fi
+
+if sudo -n true 2>/dev/null; then
+    echo "✅ User has passwordless sudo access"
+else
+    echo "⚠️  User does not have passwordless sudo access"
+fi
+echo
+
+echo "=== Docker Test Summary ==="
+echo "Docker-in-Docker setup appears to be working correctly!"
+echo "You should now be able to run Moose with Docker dependencies."
+echo
+echo "To test with Moose:"
+echo "1. Run 'moose up' or your Moose startup command"
+echo "2. Check that Docker containers start successfully"
+echo "3. Verify that Moose can connect to its services"

--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ MooseStack is open source, and apps built with MooseStack can be self-hosted. Fo
 
 [Join us on Slack](https://join.slack.com/t/moose-community/shared_invite/zt-2fjh5n3wz-cnOmM9Xe9DYAgQrNu8xKxg)
 
+## Cursor Background Agents
+
+MooseStack works with Cursor's background agents for remote development. The repository includes a pre-configured Docker-in-Docker setup that enables Moose's Docker dependencies to run in the agent environment.
+
+### Quick Setup
+1. Enable background agents in Cursor
+2. The environment will automatically build with Docker support
+3. Run `moose dev` or other Moose commands in the agent
+
+For detailed setup instructions and troubleshooting, see [Docker Setup Documentation](.cursor/DOCKER_SETUP.md).
+
 ## Contributing
 
 We welcome contributions! See the [contribution guidelines](https://github.com/514-labs/moose/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Enable Docker-in-Docker in Cursor background agents to allow Moose to run its Docker-dependent services in remote development environments.

Previously, Moose's startup routines and test suites failed in Cursor background agents due to the absence of a running Docker daemon and related networking/permission issues. This PR configures the agent environment to install Docker, set up necessary permissions and iptables, and start the daemon automatically.

---
<a href="https://cursor.com/background-agent?bcId=bc-d619d4e3-6c92-488c-bc2d-02dd3a76a080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d619d4e3-6c92-488c-bc2d-02dd3a76a080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

