### PR TITLE
ensure safe-chain during `pnpm install ...` on local dev

### DIFF
--- a/apps/create-moose-app/package.json
+++ b/apps/create-moose-app/package.json
@@ -11,7 +11,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "license": "MIT",
   "bin": "./dist/index.js",

--- a/apps/framework-cli-e2e/package.json
+++ b/apps/framework-cli-e2e/package.json
@@ -4,7 +4,8 @@
   "description": "E2E tests for framework-cli",
   "scripts": {
     "pretest": "cd ../.. && cargo build && pnpm run build --filter=@514labs/moose-lib && ./scripts/package-templates.js",
-    "test": "mocha -r ts-node/register -p 'test/**/*.ts' --jobs 1 --slow 120000 --async-only --timeout 120000"
+    "test": "mocha -r ts-node/register -p 'test/**/*.ts' --jobs 1 --slow 120000 --async-only --timeout 120000",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "devDependencies": {
     "@iarna/toml": "^3.0.0",

--- a/apps/framework-docs/package.json
+++ b/apps/framework-docs/package.json
@@ -7,7 +7,8 @@
     "build": "npx next telemetry disable && next build",
     "postbuild": "next-sitemap",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "dependencies": {
     "@mux/mux-player-react": "^3.3.0",

--- a/apps/moose-cli-npm/package.json
+++ b/apps/moose-cli-npm/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "build": "tsc"
+    "build": "tsc",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "turbo lint",
     "clean": "turbo clean",
     "prepare": "husky install",
-    "format": "prettier --write './apps/**/*.{ts,tsx}'"
+    "format": "prettier --write './apps/**/*.{ts,tsx}'",
+    "preinstall": "node scripts/ensure-safe-check.js"
   },
   "devDependencies": {
     "@repo/eslint-config-custom": "workspace:*",

--- a/packages/design-system-base/package.json
+++ b/packages/design-system-base/package.json
@@ -27,5 +27,8 @@
       "types": "./types/design-system.d.ts",
       "default": "./lib/animation-helpers.js"
     }
+  },
+  "scripts": {
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   }
 }

--- a/packages/design-system-components/package.json
+++ b/packages/design-system-components/package.json
@@ -59,5 +59,8 @@
       "default": "./lib/animation-helpers.js"
     },
     "./utils": "./lib/utils.ts"
+  },
+  "scripts": {
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   }
 }

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -14,5 +14,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   }
 }

--- a/packages/event-capture/package.json
+++ b/packages/event-capture/package.json
@@ -15,5 +15,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.74"
+  },
+  "scripts": {
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   }
 }

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -5,5 +5,8 @@
   "main": "index.js",
   "devDependencies": {
     "tailwindcss": "^3.2.4"
+  },
+  "scripts": {
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   }
 }

--- a/packages/ts-config/package.json
+++ b/packages/ts-config/package.json
@@ -5,5 +5,8 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   }
 }

--- a/packages/ts-connector-api/package.json
+++ b/packages/ts-connector-api/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "tsup",
-    "test": "mocha -r ts-node/register 'src/**/*.test.ts'"
+    "test": "mocha -r ts-node/register 'src/**/*.test.ts'",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "devDependencies": {
     "@514labs/moose-lib": "workspace:*",

--- a/packages/ts-connector-s3/package.json
+++ b/packages/ts-connector-s3/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "tsup",
-    "test": "mocha -r ts-node/register 'src/**/*.test.ts'"
+    "test": "mocha -r ts-node/register 'src/**/*.test.ts'",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.832.0"

--- a/packages/ts-moose-lib/package.json
+++ b/packages/ts-moose-lib/package.json
@@ -28,7 +28,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "tsup",
-    "test": "mocha -r ts-node/register 'src/**/*.test.ts'"
+    "test": "mocha -r ts-node/register 'src/**/*.test.ts'",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "dependencies": {
     "@clickhouse/client": "1.8.1",

--- a/packages/ts-moose-proto/package.json
+++ b/packages/ts-moose-proto/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "gen": "rimraf generated && mkdir generated && buf generate",
-    "build": "tsup"
+    "build": "tsup",
+    "preinstall": "node ../../scripts/ensure-safe-check.js"
   },
   "dependencies": {
     "@bufbuild/buf": "^1.45.0",

--- a/scripts/ensure-safe-check.js
+++ b/scripts/ensure-safe-check.js
@@ -17,13 +17,13 @@ function checkSafeChain() {
   // We need to run the test in a shell context to properly test if safe-chain is working
 
   spawn(
-    "source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null && pnpm install --workspace-root safe-chain-test 2&>1 >/dev/null",
+    "source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null && pnpm install --no-lockfile --ignore-scripts --ignore-workspace safe-chain-test 2>/dev/null >/dev/null",
     [],
     { stdio: "inherit", shell: process.env.SHELL || "/bin/bash" },
   ).on("close", (code) => {
     if (code !== 0) {
       // Safe-chain blocked the installation - this is the expected behavior
-      console.log("✅ Safe-chain is properly installed and configured");
+      // console.log("✅ Safe-chain is properly installed and configured");
 
       process.exit(0);
     }

--- a/scripts/ensure-safe-check.js
+++ b/scripts/ensure-safe-check.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const { spawn } = require("child_process");
+
+function checkSafeChain() {
+  // Skip check in CI environments
+  if (process.env.CI) {
+    console.log("⚠️  Skipping safe-chain check in CI environment");
+    console.log(
+      "ℹ️  For CI/CD integration, see: https://help.aikido.dev/code-scanning/aikido-malware-scanning/malware-scanning-with-safe-chain-in-ci-cd-environments",
+    );
+
+    process.exit(0);
+  }
+
+  // Safe-chain works by wrapping package managers with shell aliases/functions
+  // We need to run the test in a shell context to properly test if safe-chain is working
+
+  spawn(
+    "source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null && pnpm install --workspace-root safe-chain-test 2&>1 >/dev/null",
+    [],
+    { stdio: "inherit", shell: process.env.SHELL || "/bin/bash" },
+  ).on("close", (code) => {
+    if (code !== 0) {
+      // Safe-chain blocked the installation - this is the expected behavior
+      console.log("✅ Safe-chain is properly installed and configured");
+
+      process.exit(0);
+    }
+
+    // If we get here, safe-chain is NOT working (it should have blocked the install)
+    console.error("❌ Safe-chain is not properly installed or configured");
+    console.error('   The test package "safe-chain-test" was not blocked');
+    console.error("");
+    console.error("📋 To install and configure safe-chain:");
+    console.error("   1. npm install -g @aikidosec/safe-chain");
+    console.error("   2. safe-chain setup");
+    console.error("   3. Restart your terminal");
+    console.error("   4. Verify with: npm install safe-chain-test");
+    console.error("");
+    console.error(
+      "🛡️  Safe-chain protects against malicious packages during installation.",
+    );
+    console.error("📖 More info: https://github.com/AikidoSec/safe-chain");
+    console.error("");
+
+    process.exit(1);
+  });
+}
+
+checkSafeChain();

--- a/scripts/ensure-safe-check.js
+++ b/scripts/ensure-safe-check.js
@@ -56,7 +56,7 @@ function checkSafeChain() {
       process.exit(0);
     }
 
-    // In unexpcted cases exit 1 to be cautious
+    // In unexpected cases exit 1 to be cautious
     process.exit(1);
   });
 }

--- a/scripts/ensure-safe-check.js
+++ b/scripts/ensure-safe-check.js
@@ -16,34 +16,47 @@ function checkSafeChain() {
   // Safe-chain works by wrapping package managers with shell aliases/functions
   // We need to run the test in a shell context to properly test if safe-chain is working
 
-  spawn(
+  const child = spawn(
     "source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null && pnpm install --no-lockfile --ignore-scripts --ignore-workspace safe-chain-test 2>/dev/null >/dev/null",
     [],
-    { stdio: "inherit", shell: process.env.SHELL || "/bin/bash" },
-  ).on("close", (code) => {
-    if (code !== 0) {
-      // Safe-chain blocked the installation - this is the expected behavior
-      // console.log("✅ Safe-chain is properly installed and configured");
+    { stdio: "pipe", shell: process.env.SHELL || "/bin/bash" },
+  );
 
+  child.on("error", (error) => {
+    console.error("❌ Failed to run test command:", error.message);
+    console.error("   Unable to verify safe-chain status");
+    process.exit(1);
+  });
+
+  child.on("close", (code) => {
+    if (code === 0) {
+      // Command succeeded - safe-chain is NOT working (it should have blocked the install)
+      console.error("❌ Safe-chain is not properly installed or configured");
+      console.error('   The test package "safe-chain-test" was not blocked');
+      console.error("");
+      console.error("📋 To install and configure safe-chain:");
+      console.error("   1. npm install -g @aikidosec/safe-chain");
+      console.error("   2. safe-chain setup");
+      console.error("   3. Restart your terminal");
+      console.error("   4. Verify with: npm install safe-chain-test");
+      console.error("");
+      console.error(
+        "🛡️  Safe-chain protects against malicious packages during installation.",
+      );
+      console.error("📖 More info: https://github.com/AikidoSec/safe-chain");
+      console.error("");
+      process.exit(1);
+    } else if (code === 127) {
+      // Command not found (pnpm not installed)
+      console.error("❌ pnpm not found - unable to verify safe-chain status");
+      process.exit(1);
+    } else if (code === 1) {
+      // Non-zero exit code - likely safe-chain blocked the installation
+      // console.log("✅ Safe-chain is properly installed and configured");
       process.exit(0);
     }
 
-    // If we get here, safe-chain is NOT working (it should have blocked the install)
-    console.error("❌ Safe-chain is not properly installed or configured");
-    console.error('   The test package "safe-chain-test" was not blocked');
-    console.error("");
-    console.error("📋 To install and configure safe-chain:");
-    console.error("   1. npm install -g @aikidosec/safe-chain");
-    console.error("   2. safe-chain setup");
-    console.error("   3. Restart your terminal");
-    console.error("   4. Verify with: npm install safe-chain-test");
-    console.error("");
-    console.error(
-      "🛡️  Safe-chain protects against malicious packages during installation.",
-    );
-    console.error("📖 More info: https://github.com/AikidoSec/safe-chain");
-    console.error("");
-
+    // In unexpcted cases exit 1 to be cautious
     process.exit(1);
   });
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,5 +3,8 @@
   "type": "commonjs",
   "dependencies": {
     "@iarna/toml": "^3.0.0"
+  },
+  "scripts": {
+    "preinstall": "node ./ensure-safe-check.js"
   }
 }


### PR DESCRIPTION
Add preinstall script to package.json's which ensures [@aikidosec/safe-chain](https://github.com/AikidoSec/safe-chain) is installed & configured when installing packages locally.

The preinstall script issues a warning and causes `pnpm install` to exit non-zero.

The check is only performed in non-CI environments.