### PR TITLE
Clean up py-moose-lib imports

### DIFF
--- a/packages/py-moose-lib/moose_lib/__init__.py
+++ b/packages/py-moose-lib/moose_lib/__init__.py
@@ -9,3 +9,8 @@ from .data_models import *
 from .dmv2 import *
 
 from .clients.redis_client import MooseCache
+
+# Additional top-level re-exports for cleaner imports
+from .config.runtime import config_registry
+from .dmv2.materialized_view import MaterializedView, MaterializedViewOptions
+from .blocks import MergeTreeEngine


### PR DESCRIPTION
Add top-level re-exports to `moose_lib/__init__.py` to simplify imports for key classes and configurations.

---
[Slack Thread](https://fiveonefour-workspace.slack.com/archives/C08BYKG5P7C/p1758151487694859?thread_ts=1758151487.694859&cid=C08BYKG5P7C)

<a href="https://cursor.com/background-agent?bcId=bc-dd9e88d3-3dfc-4f38-9045-ea6ddc537daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd9e88d3-3dfc-4f38-9045-ea6ddc537daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

