### PR TITLE
Investigate UTM webhook DLQ logging

### DIFF
--- a/packages/py-moose-lib/moose_lib/streaming/streaming_function_runner.py
+++ b/packages/py-moose-lib/moose_lib/streaming/streaming_function_runner.py
@@ -243,7 +243,7 @@ sasl_config = {
 # When migrating - make sure the ACLs are updated to use the new prefix. 
 # And make sure the prefixes are the same in the ts-moose-lib and py-moose-lib
 streaming_function_id = f'flow-{source_topic.name}-{target_topic.name}' if target_topic else f'flow-{source_topic.name}'
-log_prefix = f"{source_topic.name} -> {target_topic.name}" if target_topic else f"{source_topic.name} -> None"
+log_prefix = f"{source_topic.name} -> {target_topic.name}" if target_topic else f"{source_topic.name} (consumer)"
 
 
 def log(msg: str) -> None:

--- a/packages/ts-moose-lib/src/streaming-functions/runner.ts
+++ b/packages/ts-moose-lib/src/streaming-functions/runner.ts
@@ -744,7 +744,8 @@ const startConsumer = async (
  * ```
  */
 const buildLogger = (args: StreamingFunctionArgs, workerId: number): Logger => {
-  const logPrefix = `${args.sourceTopic.name} -> ${args.targetTopic?.name || "void"} - ${workerId}`;
+  const targetLabel = args.targetTopic?.name ? ` -> ${args.targetTopic.name}` : " (consumer)";
+  const logPrefix = `${args.sourceTopic.name}${targetLabel} (worker ${workerId})`;
   const logger: Logger = {
     logPrefix: logPrefix,
     log: (message: string): void => {


### PR DESCRIPTION
Replace "-> void/None" with "(consumer)" in log prefixes for consumer-only flows to improve clarity and avoid confusion with DLQ messages.

---
Linear Issue: [ENG-868](https://linear.app/514/issue/ENG-868/dlq-console-logs-even-when-no-error)

<a href="https://cursor.com/background-agent?bcId=bc-ea6b5cf9-488b-466e-b8a1-2e7347a51135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea6b5cf9-488b-466e-b8a1-2e7347a51135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

