### PR TITLE
chore: add tests for the different combination of schemas we support

### DIFF
--- a/apps/framework-cli-e2e/test/constants.ts
+++ b/apps/framework-cli-e2e/test/constants.ts
@@ -30,6 +30,9 @@ export const TIMEOUTS = {
 
   // Brief cleanup wait (1 second)
   BRIEF_CLEANUP_WAIT_MS: 1_000,
+
+  // Schema validation timeout (30 seconds)
+  SCHEMA_VALIDATION_MS: 30_000,
 } as const;
 
 // Retry configuration

--- a/apps/framework-cli-e2e/test/utils/database-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/database-utils.ts
@@ -162,3 +162,301 @@ export const verifyClickhouseData = async (
     },
   );
 };
+
+// ============ SCHEMA INTROSPECTION UTILITIES ============
+
+/**
+ * Represents a ClickHouse column definition
+ */
+export interface ClickHouseColumn {
+  name: string;
+  type: string;
+  default_kind: string;
+  default_expression: string;
+  comment: string;
+  codec_expression: string;
+  ttl_expression: string;
+}
+
+/**
+ * Represents expected column schema for validation
+ */
+export interface ExpectedColumn {
+  name: string;
+  type: string | RegExp; // Allow regex for complex type matching
+  nullable?: boolean;
+  comment?: string;
+}
+
+/**
+ * Represents expected table schema for validation
+ */
+export interface ExpectedTableSchema {
+  tableName: string;
+  columns: ExpectedColumn[];
+  engine?: string;
+  orderBy?: string[];
+}
+
+/**
+ * Gets the schema for a specific table from ClickHouse
+ */
+export const getTableSchema = async (
+  tableName: string,
+): Promise<ClickHouseColumn[]> => {
+  const client = createClient(CLICKHOUSE_CONFIG);
+  try {
+    const result = await client.query({
+      query: `DESCRIBE TABLE ${tableName}`,
+      format: "JSONEachRow",
+    });
+    const columns: ClickHouseColumn[] = await result.json();
+    return columns;
+  } finally {
+    await client.close();
+  }
+};
+
+/**
+ * Gets table creation DDL to inspect engine and settings
+ */
+export const getTableDDL = async (tableName: string): Promise<string> => {
+  const client = createClient(CLICKHOUSE_CONFIG);
+  try {
+    const result = await client.query({
+      query: `SHOW CREATE TABLE ${tableName}`,
+      format: "JSONEachRow",
+    });
+    const rows: any[] = await result.json();
+    return rows[0]?.statement || "";
+  } finally {
+    await client.close();
+  }
+};
+
+/**
+ * Lists all tables in the current database
+ */
+export const getAllTables = async (): Promise<string[]> => {
+  const client = createClient(CLICKHOUSE_CONFIG);
+  try {
+    const result = await client.query({
+      query: "SHOW TABLES",
+      format: "JSONEachRow",
+    });
+    const tables: any[] = await result.json();
+    return tables.map((t) => t.name);
+  } finally {
+    await client.close();
+  }
+};
+
+/**
+ * Validates that a table schema matches expected structure
+ */
+export const validateTableSchema = async (
+  expectedSchema: ExpectedTableSchema,
+): Promise<{ valid: boolean; errors: string[] }> => {
+  const errors: string[] = [];
+
+  try {
+    // Check if table exists
+    const allTables = await getAllTables();
+    if (!allTables.includes(expectedSchema.tableName)) {
+      errors.push(`Table '${expectedSchema.tableName}' does not exist`);
+      return { valid: false, errors };
+    }
+
+    // Get actual schema
+    const actualColumns = await getTableSchema(expectedSchema.tableName);
+    const actualColumnMap = new Map(
+      actualColumns.map((col) => [col.name, col]),
+    );
+
+    // Check each expected column
+    for (const expectedCol of expectedSchema.columns) {
+      const actualCol = actualColumnMap.get(expectedCol.name);
+
+      if (!actualCol) {
+        errors.push(
+          `Column '${expectedCol.name}' is missing from table '${expectedSchema.tableName}'`,
+        );
+        continue;
+      }
+
+      // Type validation
+      const expectedType = expectedCol.type;
+      const actualType = actualCol.type;
+
+      let typeMatches = false;
+      if (typeof expectedType === "string") {
+        // Exact string match
+        typeMatches = actualType === expectedType;
+      } else if (expectedType instanceof RegExp) {
+        // Regex match for complex types
+        typeMatches = expectedType.test(actualType);
+      }
+
+      if (!typeMatches) {
+        errors.push(
+          `Column '${expectedCol.name}' type mismatch: expected '${expectedType}', got '${actualType}'`,
+        );
+      }
+
+      // Nullable validation
+      if (expectedCol.nullable !== undefined) {
+        const isNullable = actualType.includes("Nullable");
+        if (expectedCol.nullable !== isNullable) {
+          errors.push(
+            `Column '${expectedCol.name}' nullable mismatch: expected ${expectedCol.nullable}, got ${isNullable}`,
+          );
+        }
+      }
+
+      // Comment validation (if specified)
+      if (
+        expectedCol.comment !== undefined &&
+        actualCol.comment !== expectedCol.comment
+      ) {
+        errors.push(
+          `Column '${expectedCol.name}' comment mismatch: expected '${expectedCol.comment}', got '${actualCol.comment}'`,
+        );
+      }
+    }
+
+    // Check for unexpected columns (optional - could be made configurable)
+    const expectedColumnNames = new Set(
+      expectedSchema.columns.map((col) => col.name),
+    );
+    for (const actualCol of actualColumns) {
+      if (!expectedColumnNames.has(actualCol.name)) {
+        console.warn(
+          `Unexpected column '${actualCol.name}' found in table '${expectedSchema.tableName}'`,
+        );
+      }
+    }
+
+    // Validate table engine and settings if specified
+    if (expectedSchema.engine || expectedSchema.orderBy) {
+      const ddl = await getTableDDL(expectedSchema.tableName);
+
+      if (
+        expectedSchema.engine &&
+        !ddl.includes(`ENGINE = ${expectedSchema.engine}`)
+      ) {
+        errors.push(
+          `Table '${expectedSchema.tableName}' engine mismatch: expected '${expectedSchema.engine}'`,
+        );
+      }
+
+      if (expectedSchema.orderBy) {
+        const expectedOrderBy = expectedSchema.orderBy.join(", ");
+        if (!ddl.includes(`ORDER BY (${expectedOrderBy})`)) {
+          errors.push(
+            `Table '${expectedSchema.tableName}' ORDER BY mismatch: expected '(${expectedOrderBy})'`,
+          );
+        }
+      }
+    }
+  } catch (error) {
+    errors.push(
+      `Error validating schema for table '${expectedSchema.tableName}': ${error}`,
+    );
+  }
+
+  return { valid: errors.length === 0, errors };
+};
+
+/**
+ * Validates multiple table schemas at once
+ */
+export const validateMultipleTableSchemas = async (
+  expectedSchemas: ExpectedTableSchema[],
+): Promise<{
+  valid: boolean;
+  results: Array<{ tableName: string; valid: boolean; errors: string[] }>;
+}> => {
+  const results = [];
+  let allValid = true;
+
+  for (const schema of expectedSchemas) {
+    const result = await validateTableSchema(schema);
+    results.push({
+      tableName: schema.tableName,
+      valid: result.valid,
+      errors: result.errors,
+    });
+
+    if (!result.valid) {
+      allValid = false;
+    }
+  }
+
+  return { valid: allValid, results };
+};
+
+/**
+ * Pretty prints schema validation results
+ */
+export const printSchemaValidationResults = (
+  results: Array<{ tableName: string; valid: boolean; errors: string[] }>,
+): void => {
+  console.log("\n=== Schema Validation Results ===");
+
+  for (const result of results) {
+    if (result.valid) {
+      console.log(`✅ ${result.tableName}: Schema validation passed`);
+    } else {
+      console.log(`❌ ${result.tableName}: Schema validation failed`);
+      result.errors.forEach((error) => {
+        console.log(`   - ${error}`);
+      });
+    }
+  }
+
+  console.log("================================\n");
+};
+
+/**
+ * Prints actual table schemas for debugging purposes
+ */
+export const printActualTableSchemas = async (
+  tableNames: string[],
+): Promise<void> => {
+  console.log("\n=== Actual Table Schemas (for debugging) ===");
+
+  for (const tableName of tableNames) {
+    try {
+      const schema = await getTableSchema(tableName);
+      console.log(`\n📋 Table: ${tableName}`);
+      console.log("Columns:");
+      schema.forEach((col) => {
+        console.log(`  - ${col.name}: ${col.type}`);
+      });
+    } catch (error) {
+      console.log(`❌ Error getting schema for ${tableName}: ${error}`);
+    }
+  }
+
+  console.log("\n===============================================\n");
+};
+
+/**
+ * Comprehensive schema validation with detailed debugging
+ */
+export const validateSchemasWithDebugging = async (
+  expectedSchemas: ExpectedTableSchema[],
+): Promise<{
+  valid: boolean;
+  results: Array<{ tableName: string; valid: boolean; errors: string[] }>;
+}> => {
+  // First, print all actual schemas for debugging
+  const tableNames = expectedSchemas.map((s) => s.tableName);
+  await printActualTableSchemas(tableNames);
+
+  // Then run validation
+  const validationResult = await validateMultipleTableSchemas(expectedSchemas);
+  printSchemaValidationResults(validationResult.results);
+
+  return validationResult;
+};

--- a/apps/framework-cli-e2e/test/utils/index.ts
+++ b/apps/framework-cli-e2e/test/utils/index.ts
@@ -7,3 +7,4 @@ export * from "./api-utils";
 export * from "./log-utils";
 export * from "./file-utils";
 export * from "./project-setup";
+export * from "./schema-definitions";

--- a/apps/framework-cli-e2e/test/utils/schema-definitions.ts
+++ b/apps/framework-cli-e2e/test/utils/schema-definitions.ts
@@ -19,11 +19,11 @@ export const TYPESCRIPT_BASIC_SCHEMAS: ExpectedTableSchema[] = [
     tableName: "FooDeadLetter",
     columns: [
       // Based on actual ClickHouse output, DeadLetter tables have different structure
-      { name: "originalRecord", type: "String" },
+      { name: "originalRecord", type: "JSON" }, // ClickHouse uses JSON type for complex data
       { name: "errorType", type: "String" },
       { name: "failedAt", type: /DateTime\('UTC'\)/ },
       { name: "errorMessage", type: "String" },
-      { name: "source", type: "String" },
+      { name: "source", type: "LowCardinality(String)" }, // ClickHouse optimizes with LowCardinality
     ],
   },
 ];

--- a/apps/framework-cli-e2e/test/utils/schema-definitions.ts
+++ b/apps/framework-cli-e2e/test/utils/schema-definitions.ts
@@ -1,0 +1,246 @@
+import { ExpectedTableSchema } from "./database-utils";
+
+// ============ TYPESCRIPT TEMPLATE SCHEMA DEFINITIONS ============
+
+/**
+ * Expected schema for TypeScript templates - basic tables
+ */
+export const TYPESCRIPT_BASIC_SCHEMAS: ExpectedTableSchema[] = [
+  {
+    tableName: "Bar",
+    columns: [
+      { name: "primaryKey", type: "String" },
+      { name: "utcTimestamp", type: /DateTime\('UTC'\)/ },
+      { name: "hasText", type: "Bool" },
+      { name: "textLength", type: "Float64" }, // ClickHouse uses Float64 for numbers
+    ],
+  },
+  {
+    tableName: "FooDeadLetter",
+    columns: [
+      // Based on actual ClickHouse output, DeadLetter tables have different structure
+      { name: "originalRecord", type: "String" },
+      { name: "errorType", type: "String" },
+      { name: "failedAt", type: /DateTime\('UTC'\)/ },
+      { name: "errorMessage", type: "String" },
+      { name: "source", type: "String" },
+    ],
+  },
+];
+
+/**
+ * Expected schema for TypeScript test templates - comprehensive test tables
+ */
+export const TYPESCRIPT_TEST_SCHEMAS: ExpectedTableSchema[] = [
+  ...TYPESCRIPT_BASIC_SCHEMAS,
+  {
+    tableName: "BasicTypes",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "stringField", type: "String" },
+      { name: "numberField", type: "Float64" },
+      { name: "booleanField", type: "Bool" },
+      { name: "optionalString", type: "Nullable(String)", nullable: true },
+      { name: "nullableNumber", type: "Nullable(Float64)", nullable: true },
+    ],
+  },
+  {
+    tableName: "SimpleArrays",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "stringArray", type: /Array\(String\)/ },
+      { name: "numberArray", type: /Array\(Float64\)/ },
+      { name: "booleanArray", type: /Array\(Bool\)/ },
+      { name: "optionalStringArray", type: /Array\(String\)/ }, // ClickHouse doesn't make optional arrays nullable
+      { name: "mixedOptionalArray", type: /Array\(String\)/ },
+    ],
+  },
+  {
+    tableName: "NestedObjects",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      // Nested objects are typically flattened or stored as Nested columns in ClickHouse
+      { name: "address", type: /Nested\(.*\)/ },
+      { name: "metadata", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "ArraysOfObjects",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "users", type: /Nested\(.*\)/ },
+      { name: "transactions", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "DeeplyNestedArrays",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      // Multi-dimensional arrays
+      { name: "matrix2D", type: /Array\(Array\(Float64\)\)/ },
+      { name: "matrix3D", type: /Array\(Array\(Array\(Float64\)\)\)/ },
+      { name: "matrix4D", type: /Array\(Array\(Array\(Array\(Float64\)\)\)\)/ },
+      { name: "complexNested", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "MixedComplexTypes",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "events", type: /Nested\(.*\)/ },
+      { name: "nestedData", type: /Nested\(.*\)/ },
+      { name: "complexMatrix", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "EdgeCases",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "emptyStringArray", type: /Array\(String\)/ },
+      { name: "emptyObjectArray", type: /Nested\(.*\)/ },
+      { name: "nullableString", type: "Nullable(String)", nullable: true },
+      { name: "nullableNumber", type: "Nullable(Float64)", nullable: true },
+      { name: "moderateNesting", type: /Nested\(.*\)/ },
+      { name: "complexArray", type: /Nested\(.*\)/ },
+    ],
+  },
+];
+
+// ============ PYTHON TEMPLATE SCHEMA DEFINITIONS ============
+
+/**
+ * Expected schema for Python templates - basic tables
+ */
+export const PYTHON_BASIC_SCHEMAS: ExpectedTableSchema[] = [
+  {
+    tableName: "Bar",
+    columns: [
+      { name: "primary_key", type: "String" },
+      { name: "utc_timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "baz", type: /Enum8\(.*\)/ }, // Enum becomes Enum8 in ClickHouse
+      { name: "has_text", type: "Bool" },
+      { name: "text_length", type: "Int64" }, // ClickHouse uses Int64 for integers
+    ],
+  },
+];
+
+/**
+ * Expected schema for Python test templates - comprehensive test tables
+ */
+export const PYTHON_TEST_SCHEMAS: ExpectedTableSchema[] = [
+  ...PYTHON_BASIC_SCHEMAS,
+  {
+    tableName: "BasicTypes",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "string_field", type: "String" },
+      { name: "number_field", type: "Float64" },
+      { name: "boolean_field", type: "Bool" },
+      { name: "optional_string", type: "Nullable(String)", nullable: true },
+      { name: "nullable_number", type: "Nullable(Float64)", nullable: true },
+    ],
+  },
+  {
+    tableName: "SimpleArrays",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "string_array", type: /Array\(String\)/ },
+      { name: "number_array", type: /Array\(Float64\)/ },
+      { name: "boolean_array", type: /Array\(Bool\)/ },
+      { name: "optional_string_array", type: /Array\(String\)/ }, // ClickHouse doesn't make optional arrays nullable
+      { name: "mixed_optional_array", type: /Array\(String\)/ },
+    ],
+  },
+  {
+    tableName: "NestedObjects",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "address", type: /Nested\(.*\)/ },
+      { name: "metadata", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "ArraysOfObjects",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "users", type: /Nested\(.*\)/ },
+      { name: "transactions", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "DeeplyNestedArrays",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      // Multi-dimensional arrays
+      { name: "matrix_2d", type: /Array\(Array\(Float64\)\)/ },
+      { name: "matrix_3d", type: /Array\(Array\(Array\(Float64\)\)\)/ },
+      {
+        name: "matrix_4d",
+        type: /Array\(Array\(Array\(Array\(Float64\)\)\)\)/,
+      },
+      { name: "complex_nested", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "MixedComplexTypes",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "events", type: /Nested\(.*\)/ },
+      { name: "nested_data", type: /Nested\(.*\)/ },
+      { name: "complex_matrix", type: /Nested\(.*\)/ },
+    ],
+  },
+  {
+    tableName: "EdgeCases",
+    columns: [
+      { name: "id", type: "String" },
+      { name: "timestamp", type: /DateTime\('UTC'\)/ },
+      { name: "empty_string_array", type: /Array\(String\)/ },
+      { name: "empty_object_array", type: /Nested\(.*\)/ },
+      { name: "nullable_string", type: "Nullable(String)", nullable: true },
+      { name: "nullable_number", type: "Nullable(Float64)", nullable: true },
+      { name: "moderate_nesting", type: /Nested\(.*\)/ },
+      { name: "complex_array", type: /Nested\(.*\)/ },
+    ],
+  },
+];
+
+// ============ HELPER FUNCTIONS ============
+
+/**
+ * Get expected schemas based on template type
+ */
+export const getExpectedSchemas = (
+  language: "typescript" | "python",
+  isTestsVariant: boolean,
+): ExpectedTableSchema[] => {
+  if (language === "typescript") {
+    return isTestsVariant ? TYPESCRIPT_TEST_SCHEMAS : TYPESCRIPT_BASIC_SCHEMAS;
+  } else {
+    return isTestsVariant ? PYTHON_TEST_SCHEMAS : PYTHON_BASIC_SCHEMAS;
+  }
+};
+
+/**
+ * Get table names that should exist for a given template
+ */
+export const getExpectedTableNames = (
+  language: "typescript" | "python",
+  isTestsVariant: boolean,
+): string[] => {
+  const schemas = getExpectedSchemas(language, isTestsVariant);
+  return schemas.map((schema) => schema.tableName);
+};

--- a/templates/python-tests/app/ingest/models.py
+++ b/templates/python-tests/app/ingest/models.py
@@ -41,3 +41,228 @@ barModel = IngestPipeline[Bar]("Bar", IngestPipelineConfig(
     table=True,
     dead_letter_queue=True
 ))
+
+# =======Comprehensive Type Testing Data Models=========
+
+from typing import List, Tuple
+from pydantic import Field
+
+# Test 1: Basic primitive types
+class BasicTypes(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    string_field: str
+    number_field: float
+    boolean_field: bool
+    optional_string: Optional[str] = None
+    nullable_number: Optional[float] = None
+
+# Test 2: Simple arrays of primitives
+class SimpleArrays(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    string_array: List[str]
+    number_array: List[float]
+    boolean_array: List[bool]
+    optional_string_array: Optional[List[str]] = None
+    mixed_optional_array: Optional[List[str]] = None
+
+# Test 3: Nested objects
+class Coordinates(BaseModel):
+    lat: float
+    lng: float
+
+class Address(BaseModel):
+    street: str
+    city: str
+    coordinates: Coordinates
+
+class Settings(BaseModel):
+    theme: str
+    notifications: bool
+
+class Config(BaseModel):
+    enabled: bool
+    settings: Settings
+
+class Metadata(BaseModel):
+    tags: List[str]
+    priority: int
+    config: Config
+
+class NestedObjects(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    address: Address
+    metadata: Metadata
+
+# Test 4: Arrays of objects
+class User(BaseModel):
+    name: str
+    age: int
+    active: bool
+
+class TransactionMetadata(BaseModel):
+    category: str
+    tags: List[str]
+
+class Transaction(BaseModel):
+    id: str
+    amount: float
+    currency: str
+    metadata: TransactionMetadata
+
+class ArraysOfObjects(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    users: List[User]
+    transactions: List[Transaction]
+
+# Test 5: Deeply nested arrays (main focus for ENG-875) - ClickHouse compatible
+class SimplifiedItem(BaseModel):
+    name: str
+    values: List[float]
+    data: List[str]
+    # Flattened structure instead of deeply nested objects
+    metric_names: List[str]
+    metric_values: List[float]
+
+class ComplexNestedCategory(BaseModel):
+    category: str
+    items: List[SimplifiedItem]
+
+class DeeplyNestedArrays(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    # Level 1: Array of arrays (safe)
+    matrix_2d: List[List[float]]
+    # Level 2: Array of arrays of arrays (safe)
+    matrix_3d: List[List[List[float]]]
+    # Level 3: Array of arrays of arrays of arrays (pushing limits but should work)
+    matrix_4d: List[List[List[List[float]]]]
+    # Simplified nested: Reduce nesting depth to avoid ClickHouse issues
+    complex_nested: List[ComplexNestedCategory]
+
+# Test 6: Mixed complex types (ClickHouse-safe)
+class ClickEvent(BaseModel):
+    type: str = Field(default="click")
+    target: str
+    coordinate_x: float
+    coordinate_y: float
+
+class FlattenedData(BaseModel):
+    required: str
+    optional_data: List[str]  # Flattened, no nested optionals
+    tags: List[str]
+    values: List[float]
+
+class Column(BaseModel):
+    col: int
+    values: List[str]
+
+class ComplexMatrixRow(BaseModel):
+    row: int
+    columns: List[Column]
+
+class MixedComplexTypes(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    # Arrays with click events (safe)
+    events: List[ClickEvent]
+    # Flattened optional structures (avoid nested optionals)
+    nested_data: List[FlattenedData]
+    # Multi-dimensional with objects (safe)
+    complex_matrix: List[ComplexMatrixRow]
+
+# Test 7: Edge cases and boundary conditions (ClickHouse-compatible)
+class EmptyObject(BaseModel):
+    id: str
+
+class Property(BaseModel):
+    key: str
+    value: str
+    tags: List[str]
+
+class Metric(BaseModel):
+    name: str
+    values: List[float]
+
+class ModerateLevel2(BaseModel):
+    data: List[str]
+    values: List[float]
+
+class ModerateLevel1(BaseModel):
+    level2: List[ModerateLevel2]
+
+class ModerateNesting(BaseModel):
+    level1: List[ModerateLevel1]
+
+class SimplifiedComplexItem(BaseModel):
+    id: str
+    properties: List[Property]
+    metrics: List[Metric]
+
+class EdgeCases(BaseModel):
+    id: Key[str]
+    timestamp: datetime
+    # Empty arrays (safe)
+    empty_string_array: List[str]
+    empty_object_array: List[EmptyObject]
+    # Simplified nullable structures (avoid nested nullables)
+    nullable_string: Optional[str] = None
+    nullable_number: Optional[float] = None
+    # Moderate depth nesting (3 levels max for safety)
+    moderate_nesting: ModerateNesting
+    # Simplified complex arrays
+    complex_array: List[SimplifiedComplexItem]
+
+# =======Pipeline Configurations for Test Models=========
+
+basic_types_model = IngestPipeline[BasicTypes]("BasicTypes", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))
+
+simple_arrays_model = IngestPipeline[SimpleArrays]("SimpleArrays", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))
+
+nested_objects_model = IngestPipeline[NestedObjects]("NestedObjects", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))
+
+arrays_of_objects_model = IngestPipeline[ArraysOfObjects]("ArraysOfObjects", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))
+
+deeply_nested_arrays_model = IngestPipeline[DeeplyNestedArrays]("DeeplyNestedArrays", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))
+
+mixed_complex_types_model = IngestPipeline[MixedComplexTypes]("MixedComplexTypes", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))
+
+edge_cases_model = IngestPipeline[EdgeCases]("EdgeCases", IngestPipelineConfig(
+    ingest=True,
+    stream=True,
+    table=True,
+    dead_letter_queue=True
+))

--- a/templates/typescript-tests/app/ingest/models.ts
+++ b/templates/typescript-tests/app/ingest/models.ts
@@ -50,3 +50,215 @@ export const BarPipeline = new IngestPipeline<Bar>("Bar", {
   stream: true, // Buffer processed records
   ingest: false, // No API; only derive from processed Foo records
 });
+
+/** =======Comprehensive Type Testing Data Models========= */
+
+/** Test 1: Basic primitive types */
+export interface BasicTypes {
+  id: Key<string>;
+  timestamp: DateTime;
+  stringField: string;
+  numberField: number;
+  booleanField: boolean;
+  optionalString?: string;
+  nullableNumber: number | null;
+}
+
+/** Test 2: Simple arrays of primitives */
+export interface SimpleArrays {
+  id: Key<string>;
+  timestamp: DateTime;
+  stringArray: string[];
+  numberArray: number[];
+  booleanArray: boolean[];
+  optionalStringArray?: string[];
+  mixedOptionalArray?: string[];
+}
+
+/** Test 3: Nested objects */
+export interface NestedObjects {
+  id: Key<string>;
+  timestamp: DateTime;
+  address: {
+    street: string;
+    city: string;
+    coordinates: {
+      lat: number;
+      lng: number;
+    };
+  };
+  metadata: {
+    tags: string[];
+    priority: number;
+    config: {
+      enabled: boolean;
+      settings: {
+        theme: string;
+        notifications: boolean;
+      };
+    };
+  };
+}
+
+/** Test 4: Arrays of objects */
+export interface ArraysOfObjects {
+  id: Key<string>;
+  timestamp: DateTime;
+  users: {
+    name: string;
+    age: number;
+    active: boolean;
+  }[];
+  transactions: {
+    id: string;
+    amount: number;
+    currency: string;
+    metadata: {
+      category: string;
+      tags: string[];
+    };
+  }[];
+}
+
+/** Test 5: Deeply nested arrays (main focus for ENG-875) - ClickHouse compatible */
+export interface DeeplyNestedArrays {
+  id: Key<string>;
+  timestamp: DateTime;
+  // Level 1: Array of arrays (safe)
+  matrix2D: number[][];
+  // Level 2: Array of arrays of arrays (safe)
+  matrix3D: number[][][];
+  // Level 3: Array of arrays of arrays of arrays (pushing limits but should work)
+  matrix4D: number[][][][];
+  // Simplified nested: Reduce nesting depth to avoid ClickHouse issues
+  complexNested: {
+    category: string;
+    items: {
+      name: string;
+      values: number[];
+      data: string[];
+      // Flattened structure instead of deeply nested objects
+      metricNames: string[];
+      metricValues: number[];
+    }[];
+  }[];
+}
+
+/** Test 6: Mixed complex types (ClickHouse-safe) */
+export interface MixedComplexTypes {
+  id: Key<string>;
+  timestamp: DateTime;
+  // Arrays with click events (safe)
+  events: {
+    type: string;
+    target: string;
+    coordinateX: number;
+    coordinateY: number;
+  }[];
+  // Flattened optional structures (avoid nested optionals)
+  nestedData: {
+    required: string;
+    optionalData: string[]; // Flattened, no nested optionals
+    tags: string[];
+    values: number[];
+  }[];
+  // Multi-dimensional with objects (safe)
+  complexMatrix: {
+    row: number;
+    columns: {
+      col: number;
+      values: string[];
+    }[];
+  }[];
+}
+
+/** Test 7: Edge cases and boundary conditions (ClickHouse-compatible) */
+export interface EdgeCases {
+  id: Key<string>;
+  timestamp: DateTime;
+  // Empty arrays (safe)
+  emptyStringArray: string[];
+  emptyObjectArray: { id: string }[];
+  // Simplified nullable structures (avoid nested nullables)
+  nullableString?: string;
+  nullableNumber?: number;
+  // Moderate depth nesting (3 levels max for safety)
+  moderateNesting: {
+    level1: {
+      level2: {
+        data: string[];
+        values: number[];
+      }[];
+    }[];
+  };
+  // Simplified complex arrays
+  complexArray: {
+    id: string;
+    properties: {
+      key: string;
+      value: string;
+      tags: string[];
+    }[];
+    metrics: {
+      name: string;
+      values: number[];
+    }[];
+  }[];
+}
+
+/** =======Pipeline Configurations for Test Models========= */
+
+export const BasicTypesPipeline = new IngestPipeline<BasicTypes>("BasicTypes", {
+  table: true,
+  stream: true,
+  ingest: true,
+});
+
+export const SimpleArraysPipeline = new IngestPipeline<SimpleArrays>(
+  "SimpleArrays",
+  {
+    table: true,
+    stream: true,
+    ingest: true,
+  },
+);
+
+export const NestedObjectsPipeline = new IngestPipeline<NestedObjects>(
+  "NestedObjects",
+  {
+    table: true,
+    stream: true,
+    ingest: true,
+  },
+);
+
+export const ArraysOfObjectsPipeline = new IngestPipeline<ArraysOfObjects>(
+  "ArraysOfObjects",
+  {
+    table: true,
+    stream: true,
+    ingest: true,
+  },
+);
+
+export const DeeplyNestedArraysPipeline =
+  new IngestPipeline<DeeplyNestedArrays>("DeeplyNestedArrays", {
+    table: true,
+    stream: true,
+    ingest: true,
+  });
+
+export const MixedComplexTypesPipeline = new IngestPipeline<MixedComplexTypes>(
+  "MixedComplexTypes",
+  {
+    table: true,
+    stream: true,
+    ingest: true,
+  },
+);
+
+export const EdgeCasesPipeline = new IngestPipeline<EdgeCases>("EdgeCases", {
+  table: true,
+  stream: true,
+  ingest: true,
+});


### PR DESCRIPTION
This pull request introduces comprehensive schema validation for the framework CLI end-to-end (E2E) tests, ensuring that tables created by both TypeScript and Python templates match expected ClickHouse schemas. It adds detailed schema definitions, utilities for introspecting and validating ClickHouse tables, and expands the Python test models for robust type coverage. This helps catch schema mismatches early and improves confidence in template correctness.

The most important changes are:

**Schema Validation Infrastructure:**

* Added a new schema validation utility to `database-utils.ts`, including functions and types for introspecting ClickHouse tables, validating schemas, and printing results. This enables automated checks that created tables match expected structures, types, and nullability.
* Introduced a new `schema-definitions.ts` file that defines expected table schemas for both TypeScript and Python templates, supporting both basic and test variants. Helper functions allow easy retrieval of expected schemas for each template.
* Updated the E2E test suite (`templates.test.ts`) to include a schema validation test for every template, using the new utilities and schema definitions. The test fails if any table does not match the expected schema.
* Added a schema validation timeout constant to `constants.ts` to ensure schema checks do not hang indefinitely.

**Python Template Model Expansion:**

* Greatly expanded the Python test models in `models.py` to include a wide variety of data types and structures—covering primitives, arrays, nested objects, arrays of objects, deeply nested arrays, mixed complex types, and edge cases. This ensures the Python template is thoroughly tested for ClickHouse compatibility and schema correctness.

**Test Utility Integration:**

* Exported schema definition utilities from the test utils index to make them available throughout the test codebase.
* Updated imports in `templates.test.ts` to use the new schema validation helpers.