### PR TITLE
fix

### DIFF
--- a/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
@@ -303,8 +303,8 @@ interface QueryParams {
   // Date validations
   startDate: string & tags.Format<"date">;  // YYYY-MM-DD format
   
-  // Enum validation
-  status: string & tags.Enum<"active" | "pending" | "inactive">;  // Must be one of these values
+  // Literal validation
+  status: "active" | "pending" | "inactive";  // Must be one of these values
   
   // Optional parameters
   limit?: number & tags.Type<"uint32"> & tags.Maximum<100>;  // Optional, if provided: positive integer <= 100

--- a/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
@@ -305,7 +305,7 @@ interface QueryParams {
   
   // Literal validation
   status: "active" | "pending" | "inactive";  // Must be one of these values
-  
+
   // Optional parameters
   limit?: number & tags.Type<"uint32"> & tags.Maximum<100>;  // Optional, if provided: positive integer <= 100
   
@@ -315,6 +315,21 @@ interface QueryParams {
 ```
 
 Notice its just regular TypeScript union types. For a full list of validation options, see the [Typia documentation](https://typia.io/api/tags).
+
+You can derive a safe orderBy union from your actual table columns and use it directly in SQL:
+```ts filename="ValidationExamples.ts" copy
+interface MyTableSchema {
+  column1: string;
+  column2: number;
+  column3: string;
+}
+
+const MyTable = new OlapTable<MyTableSchema>("my_table");
+
+interface QueryParams {
+  orderByColumn: keyof MyTableSchema; // validates against the column names in "my_table"
+}
+```
 </TypeScript>
 
 <Python>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces Typia enum tag with a TypeScript literal union for `status` and adds a `keyof`-based example to validate `orderBy` against table columns.
> 
> - **Docs update** (`apps/framework-docs/src/pages/moose/apis/analytics-api.mdx`):
>   - Replace `status: string & tags.Enum<...>` with literal union `status: "active" | "pending" | "inactive"`.
>   - Add example deriving `orderByColumn: keyof MyTableSchema` from an `OlapTable<MyTableSchema>` to validate column names in SQL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17f154e246e551fa1ff0bc6421ff2adadd4fb6f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->