### PR TITLE
Fix slow end-to-end test cleanup

### DIFF
--- a/apps/framework-cli-e2e/test/utils/docker-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/docker-utils.ts
@@ -24,7 +24,10 @@ const withTimeout = async <T>(
   timeoutMessage: string,
 ): Promise<T> => {
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+    const timer = setTimeout(
+      () => reject(new Error(timeoutMessage)),
+      timeoutMs,
+    );
     promise.then(
       (value) => {
         clearTimeout(timer);

--- a/apps/framework-cli-e2e/test/utils/process-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/process-utils.ts
@@ -24,9 +24,7 @@ const setTimeoutAsync = (ms: number) =>
 /**
  * Stops a development process with graceful shutdown and forced termination fallback
  */
-export const stopDevProcess = async (
-  devProcess: any,
-): Promise<void> => {
+export const stopDevProcess = async (devProcess: any): Promise<void> => {
   if (devProcess && !devProcess.killed) {
     console.log("Stopping dev process...");
     devProcess.kill("SIGINT");

--- a/apps/framework-cli-e2e/test/utils/process-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/process-utils.ts
@@ -1,16 +1,31 @@
-import { ChildProcess } from "child_process";
-import { promisify } from "util";
 import { TIMEOUTS } from "../constants";
 
-const execAsync = promisify(require("child_process").exec);
+declare const require: any;
+
+const execAsync = (
+  command: string,
+  options?: any,
+): Promise<{ stdout: string; stderr: string }> => {
+  return new Promise((resolve, reject) => {
+    require("child_process").exec(
+      command,
+      options || {},
+      (error: any, stdout: string, stderr: string) => {
+        if (error) return reject(error);
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+};
+
 const setTimeoutAsync = (ms: number) =>
-  new Promise<void>((resolve) => global.setTimeout(resolve, ms));
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /**
  * Stops a development process with graceful shutdown and forced termination fallback
  */
 export const stopDevProcess = async (
-  devProcess: ChildProcess | null,
+  devProcess: any,
 ): Promise<void> => {
   if (devProcess && !devProcess.killed) {
     console.log("Stopping dev process...");
@@ -48,17 +63,31 @@ export const stopDevProcess = async (
  * Waits for the development server to start by monitoring stdout and HTTP pings
  */
 export const waitForServerStart = async (
-  devProcess: ChildProcess,
+  devProcess: any,
   timeout: number,
   startupMessage: string,
   serverUrl: string,
 ): Promise<void> => {
   return new Promise<void>((resolve, reject) => {
     let serverStarted = false;
-    let timeoutId: ReturnType<typeof global.setTimeout>;
-    let pingInterval: ReturnType<typeof global.setInterval> | null = null;
+    let timeoutId: any = null;
+    let pingInterval: any = null;
 
-    devProcess.stdout?.on("data", async (data) => {
+    const cleanup = () => {
+      if (pingInterval) {
+        clearInterval(pingInterval);
+        pingInterval = null;
+      }
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      devProcess.stdout?.off("data", onStdout);
+      devProcess.stderr?.off("data", onStderr);
+      devProcess.off("exit", onExit);
+    };
+
+    const onStdout = async (data: any) => {
       const output = data.toString();
       if (!output.match(/^\n[⢹⢺⢼⣸⣇⡧⡗⡏] Starting local infrastructure$/)) {
         console.log("Dev server output:", output);
@@ -66,34 +95,40 @@ export const waitForServerStart = async (
 
       if (!serverStarted && output.includes(startupMessage)) {
         serverStarted = true;
-        if (pingInterval) clearInterval(pingInterval);
+        cleanup();
         resolve();
       }
-    });
+    };
 
-    devProcess.stderr?.on("data", (data) => {
+    const onStderr = (data: any) => {
       console.error("Dev server stderr:", data.toString());
-    });
+    };
 
-    devProcess.on("exit", (code) => {
+    const onExit = (code: number | null) => {
       console.log(`Dev process exited with code ${code}`);
       if (!serverStarted) {
+        cleanup();
         reject(new Error(`Dev process exited with code ${code}`));
+      } else {
+        cleanup();
       }
-    });
+    };
+
+    devProcess.stdout?.on("data", onStdout);
+    devProcess.stderr?.on("data", onStderr);
+    devProcess.on("exit", onExit);
 
     // Fallback readiness probe: HTTP ping
     pingInterval = setInterval(async () => {
       if (serverStarted) {
-        if (pingInterval) clearInterval(pingInterval);
+        cleanup();
         return;
       }
       try {
         const res = await fetch(`${serverUrl}/ingest`);
         if (res.ok || [400, 404, 405].includes(res.status)) {
           serverStarted = true;
-          if (pingInterval) clearInterval(pingInterval);
-          clearTimeout(timeoutId);
+          cleanup();
           resolve();
         }
       } catch (_) {
@@ -105,7 +140,7 @@ export const waitForServerStart = async (
       if (serverStarted) return;
       console.error("Dev server did not start or complete in time");
       devProcess.kill("SIGINT");
-      if (pingInterval) clearInterval(pingInterval);
+      cleanup();
       reject(new Error("Dev server timeout"));
     }, timeout);
   });
@@ -116,7 +151,11 @@ export const waitForServerStart = async (
  */
 export const killRemainingProcesses = async (): Promise<void> => {
   try {
-    await execAsync("pkill -f moose-cli || true");
+    await execAsync("pkill -9 -f moose-cli || true", {
+      timeout: TIMEOUTS.PROCESS_TERMINATION_MS,
+      killSignal: "SIGKILL",
+      windowsHide: true,
+    });
     console.log("Killed any remaining moose-cli processes");
   } catch (error) {
     console.warn("Error killing remaining processes:", error);

--- a/apps/framework-cli-e2e/test/utils/retry-utils.ts
+++ b/apps/framework-cli-e2e/test/utils/retry-utils.ts
@@ -1,7 +1,7 @@
 import { RETRY_CONFIG } from "../constants";
 
 const setTimeoutAsync = (ms: number) =>
-  new Promise<void>((resolve) => global.setTimeout(resolve, ms));
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export interface RetryOptions {
   attempts?: number;


### PR DESCRIPTION
Add explicit timeouts to Docker cleanup and process killing, and improve `waitForServerStart` cleanup to resolve E2E test hangs.

The E2E tests were hanging for several minutes after reporting "Global cleanup completed" due to lingering processes, unhandled Docker cleanup timeouts, and unresolved promises/listeners in the server startup wait logic. This PR addresses these by ensuring all cleanup operations have explicit timeouts and that all event listeners and timers are properly cleared.

---
Linear Issue: [ENG-879](https://linear.app/514/issue/ENG-879/e2e-tests-hang-for-4-minutes-after-completion-despite-successful)

<a href="https://cursor.com/background-agent?bcId=bc-e8f5c7ba-7e56-4b05-b27d-d6d64e0ee66f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8f5c7ba-7e56-4b05-b27d-d6d64e0ee66f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit timeouts and stronger cleanup for Docker and dev processes, plus safer server-start waiting with proper listener/timer cleanup.
> 
> - **E2E Test Utils**:
>   - **Docker** (`test/utils/docker-utils.ts`):
>     - Introduces `withTimeout` helper and applies it to `docker compose down`, volume list/removal, and `docker system prune`.
>     - Replaces `promisify(exec)` with custom `execAsync`.
>   - **Processes** (`test/utils/process-utils.ts`):
>     - Improves `waitForServerStart` by adding a `cleanup` routine to clear intervals/timeouts and remove listeners; more robust exit handling.
>     - Uses custom `execAsync`; updates `setTimeoutAsync` to `setTimeout`.
>     - `stopDevProcess` signature simplified; timer types loosened for cross-env safety.
>     - Strengthens `killRemainingProcesses` to `pkill -9` with exec options (timeout, SIGKILL, windowsHide).
>   - **Retry** (`test/utils/retry-utils.ts`): switches to `setTimeout` (non-global) in `setTimeoutAsync`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90b8e05268651e77856c552ac5bf532f101441a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->