### PR TITLE
add command method to QueryClient

### DIFF
--- a/packages/ts-moose-lib/src/consumption-apis/helpers.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/helpers.ts
@@ -1,4 +1,4 @@
-import { ClickHouseClient, ResultSet } from "@clickhouse/client";
+import { ClickHouseClient, CommandResult, ResultSet } from "@clickhouse/client";
 import {
   Client as TemporalClient,
   Connection,
@@ -59,6 +59,21 @@ export class QueryClient {
     });
     const elapsedMs = performance.now() - start;
     console.log(`[QueryClient] | Query completed: ${prettyMs(elapsedMs)}`);
+    return result;
+  }
+
+  async command(sql: Sql): Promise<CommandResult> {
+    const [query, query_params] = toQuery(sql);
+
+    console.log(`[QueryClient] | Command: ${toQueryPreview(sql)}`);
+    const start = performance.now();
+    const result = await this.client.command({
+      query,
+      query_params,
+      query_id: this.query_id_prefix + randomUUID(),
+    });
+    const elapsedMs = performance.now() - start;
+    console.log(`[QueryClient] | Command completed: ${prettyMs(elapsedMs)}`);
     return result;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `QueryClient.command(sql)` to execute ClickHouse commands with logging, timing, and query IDs.
> 
> - **Library (`packages/ts-moose-lib`)**:
>   - **QueryClient**:
>     - Adds `command(sql): Promise<CommandResult>` to run non-SELECT ClickHouse commands via `client.command`, using `toQuery`/`toQueryPreview`, prefixed `query_id`, and elapsed-time logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1aaf7f72e280a1df65076058cc919c37d3b776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->