### PR TITLE
Add missing package.json copy (fixes hosting telem deployment)

### DIFF
--- a/apps/framework-cli/src/cli/routines/docker_packager.rs
+++ b/apps/framework-cli/src/cli/routines/docker_packager.rs
@@ -120,6 +120,7 @@ WORKDIR /monorepo
 
 # Copy workspace configuration files
 COPY pnpm-workspace.yaml ./
+COPY package.json ./
 {}
 
 # Copy workspace package directories (will be replaced with actual patterns)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Include root package.json in the monorepo Docker build context for dependency installation.
> 
> - **Docker packaging (TypeScript monorepo)**:
>   - Copy root `package.json` alongside `pnpm-workspace.yaml` in `monorepo-base` stage to support workspace installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9521bae73ea44de64649f690a733a6162a9d7130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->