### PR TITLE
Rename IngestPipeline ingest parameter to ingestApi/ingest_api

### DIFF
--- a/apps/framework-docs/llm-docs/python/ingest.md
+++ b/apps/framework-docs/llm-docs/python/ingest.md
@@ -45,7 +45,7 @@ For `IngestPipeline`, configuration must be provided as keyword arguments:
 # Correct pipeline creation with keyword arguments
 brain_data_pipeline = IngestPipeline[BrainData](
     "brain_data",    # Required: Pipeline name
-    ingest=True,     # Required: Enable ingestion
+    ingest_api=True,     # Required: Enable ingestion
     stream=True,     # Required: Enable streaming
     table=True       # Required: Enable table storage
 )
@@ -141,7 +141,7 @@ When creating an ingest pipeline, you must ensure that:
 
 1. Configuration is provided as keyword arguments
 2. Required flags are set:
-   - `ingest=True` to enable ingestion
+   - `ingest_api=True` to enable ingestion
    - `stream=True` to enable streaming
    - `table=True` to enable table storage
 3. The pipeline name is provided as the first argument
@@ -150,7 +150,7 @@ When creating an ingest pipeline, you must ensure that:
 # Correct - Using keyword arguments
 pipeline = IngestPipeline[MyModel](
     "my_pipeline",
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 )

--- a/apps/framework-docs/llm-docs/python/pipelines.md
+++ b/apps/framework-docs/llm-docs/python/pipelines.md
@@ -113,8 +113,8 @@ When you create an `IngestPipeline` instance:
    - Creates a `Stream` with the specified configuration
    - Automatically connects to the table if one exists
    - If `stream` is `True`, uses default configuration
-3. If `ingest` is configured:
+3. If `ingest_api` is configured:
    - Creates an `IngestApi` with the specified configuration
    - Automatically connects to the stream
-   - If `ingest` is `True`, uses default configuration
+   - If `ingest_api` is `True`, uses default configuration
 

--- a/apps/framework-docs/llm-docs/python/schema-definition.md
+++ b/apps/framework-docs/llm-docs/python/schema-definition.md
@@ -25,7 +25,7 @@ When creating Python data models, you must follow these requirements exactly:
    - Use proper configuration objects, not dictionaries
    - Use IngestPipelineConfig for pipeline configuration
    - Use OlapConfig for table customization
-   - Set required flags (stream=True, ingest=True)
+   - Set required flags (stream=True, ingest_api=True)
    - Do not add undocumented fields to configurations
 
 Example of correct Python schema:
@@ -51,7 +51,7 @@ config = IngestPipelineConfig(
         engine=ClickHouseEngines.ReplacingMergeTree,
     ),
     stream=True,
-    ingest=True
+    ingest_api=True
 )
 
 pipeline = IngestPipeline[BrainData](
@@ -193,7 +193,7 @@ config = IngestPipelineConfig(
         engine=ClickHouseEngines.ReplacingMergeTree,
     ),
     stream=True,
-    ingest=True,
+    ingest_api=True,
     metadata={"description": "Brain data pipeline"}
 )
 
@@ -217,7 +217,7 @@ brain_data_pipeline = IngestPipeline[BrainData](
 
 1. **Pipeline Configuration**
    - Use `IngestPipelineConfig` object, not dictionaries
-   - Required flags: `ingest=True`, `stream=True`
+   - Required flags: `ingest_api=True`, `stream=True`
    - Table configuration must be either:
      - `True` for default settings
      - `OlapConfig` object for custom settings
@@ -233,7 +233,7 @@ brain_data_pipeline = IngestPipeline[BrainData](
            engine=ClickHouseEngines.ReplacingMergeTree,
        ),
        stream=True,
-       ingest=True
+       ingest_api=True
    )
    
    pipeline = IngestPipeline[MyModel](
@@ -258,7 +258,7 @@ brain_data_pipeline = IngestPipeline[BrainData](
            engine=ClickHouseEngines.ReplacingMergeTree,
        ),
        stream=True,
-       ingest=True,
+       ingest_api=True,
        metadata={"description": "My pipeline"}  # Invalid field
    )
    ```

--- a/apps/framework-docs/llm-docs/typescript/pipelines.md
+++ b/apps/framework-docs/llm-docs/typescript/pipelines.md
@@ -19,7 +19,7 @@ interface ExampleSchema {
 export const ExamplePipeline = new IngestPipeline<ExampleSchema>("ExamplePipeline", {
   table: true,      // Creates a basic table
   stream: true,     // Creates a basic stream
-  ingest: true      // Creates a basic ingest API
+  ingestApi: true      // Creates a basic ingest API
 });
 ```
 
@@ -31,7 +31,7 @@ The `IngestPipeline` class accepts the following configuration options:
 type DataModelConfigV2<T> = {
   table: boolean | OlapConfig<T>;        // Table configuration
   stream: boolean | Omit<StreamConfig, "destination">;  // Stream configuration
-  ingest: boolean | Omit<IngestConfig, "destination">;  // Ingest configuration
+  ingestApi: boolean | Omit<IngestConfig, "destination">;  // Ingest configuration
 };
 ```
 
@@ -100,7 +100,7 @@ When you create an `IngestPipeline` instance:
    - Creates a `Stream` with the specified configuration
    - Automatically connects to the table if one exists
    - If `stream` is `true`, uses default configuration
-3. If `ingest` is configured:
+3. If `ingestApi` is configured:
    - Creates an `IngestApi` with the specified configuration
    - Automatically connects to the stream
-   - If `ingest` is `true`, uses default configuration
+   - If `ingestApi` is `true`, uses default configuration

--- a/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
@@ -76,7 +76,7 @@ interface SourceSchema {
 }
 
 export const SourcePipeline = new IngestPipeline<SourceSchema>("Source", {
-  ingestAPI: false,
+  ingestApi: false,
   stream: true,
   table: true,
 });

--- a/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
@@ -79,7 +79,7 @@ export const SourcePipeline = new IngestPipeline<SourceSchema>("Source", {
   ingestAPI: false,
   stream: true,
   table: true,
-})
+});
 ```
 </ToggleBlock>
 

--- a/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/analytics-api.mdx
@@ -75,8 +75,8 @@ interface SourceSchema {
   value: number;
 }
 
-export const SourcePipeline = new IngestPipeline<SourceSchema>("Source" {
-  ingest: false,
+export const SourcePipeline = new IngestPipeline<SourceSchema>("Source", {
+  ingestAPI: false,
   stream: true,
   table: true,
 })

--- a/apps/framework-docs/src/pages/moose/apis/ingest-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/ingest-api.mdx
@@ -193,7 +193,7 @@ interface ExampleModel {
 }
 
 const examplePipeline = new IngestPipeline<ExampleModel>("example-name", {
-  ingest: true, // Creates a REST API endpoint
+  ingestApi: true, // Creates a REST API endpoint
   stream: true, // Connects to a stream
   table: true
 });
@@ -213,7 +213,7 @@ class ExampleSchema(BaseModel):
 example_pipeline = IngestPipeline[ExampleSchema](
     name="example-name",
     config=IngestPipelineConfig(
-        ingest=True,
+        ingest_api=True,
         stream=True,
         table=True
     )
@@ -281,7 +281,7 @@ Configuration options for both high-level and low-level ingestion APIs are provi
 interface IngestPipelineConfig<T> {
   table?: boolean | OlapConfig<T>;
   stream?: boolean | Omit<StreamConfig<T>, "destination">;
-  ingest?: boolean | Omit<IngestConfig<T>, "destination">;
+  ingestApi?: boolean | Omit<IngestConfig<T>, "destination">;
   deadLetterQueue?: boolean | Omit<StreamConfig<T>, "destination">;
   version?: string;
   metadata?: {
@@ -296,7 +296,7 @@ interface IngestPipelineConfig<T> {
 class IngestPipelineConfig(BaseModel):
     table: bool | OlapConfig = True
     stream: bool | StreamConfig = True
-    ingest: bool | IngestConfig = True
+    ingest_api: bool | IngestConfig = True
     dead_letter_queue: bool | StreamConfig = True
     version: Optional[str] = None
     metadata: Optional[dict] = None

--- a/apps/framework-docs/src/pages/moose/changelog.mdx
+++ b/apps/framework-docs/src/pages/moose/changelog.mdx
@@ -81,12 +81,12 @@ Changes that require user action or may break existing usage.
 ## 2025-08-20
 
 <ReleaseHighlights>
-  - **Improved IngestPipeline API Clarity** — The confusing `ingest` parameter has been renamed to `ingestAPI` (TypeScript) and `ingest_api` (Python) for better clarity. The old parameter names are still supported with deprecation warnings.
+  - **Improved IngestPipeline API Clarity** — The confusing `ingest` parameter has been renamed to `ingestApi` (TypeScript) and `ingest_api` (Python) for better clarity. The old parameter names are still supported with deprecation warnings.
 </ReleaseHighlights>
 
 <Changed>
   - **IngestPipeline Parameter Renamed** — The `ingest` parameter in IngestPipeline configurations has been renamed for clarity:
-    - **TypeScript**: `ingest: true` → `ingestAPI: true`
+    - **TypeScript**: `ingest: true` → `ingestApi: true`
     - **Python**: `ingest=True` → `ingest_api=True`
     
     The old parameter names continue to work with deprecation warnings to ensure backwards compatibility. *[Current PR]*
@@ -94,7 +94,7 @@ Changes that require user action or may break existing usage.
 
 <Deprecated>
   - **IngestPipeline `ingest` parameter** — The `ingest` parameter in IngestPipeline configurations is deprecated:
-    - **TypeScript**: Use `ingestAPI` instead of `ingest`
+    - **TypeScript**: Use `ingestApi` instead of `ingest`
     - **Python**: Use `ingest_api` instead of `ingest`
     
     The old parameter will be removed in a future major version. Please update your code to use the new parameter names. *[Current PR]*

--- a/apps/framework-docs/src/pages/moose/changelog.mdx
+++ b/apps/framework-docs/src/pages/moose/changelog.mdx
@@ -76,6 +76,35 @@ Changes that require user action or may break existing usage.
     *[#2676](https://github.com/514-labs/moosestack/pull/2676) by [camelCasedAditya](https://github.com/camelCasedAditya)*
 </BreakingChanges>
 
+---
+
+## 2025-08-20
+
+<ReleaseHighlights>
+  - **Improved IngestPipeline API Clarity** — The confusing `ingest` parameter has been renamed to `ingestAPI` (TypeScript) and `ingest_api` (Python) for better clarity. The old parameter names are still supported with deprecation warnings.
+</ReleaseHighlights>
+
+<Changed>
+  - **IngestPipeline Parameter Renamed** — The `ingest` parameter in IngestPipeline configurations has been renamed for clarity:
+    - **TypeScript**: `ingest: true` → `ingestAPI: true`
+    - **Python**: `ingest=True` → `ingest_api=True`
+    
+    The old parameter names continue to work with deprecation warnings to ensure backwards compatibility. *[Current PR]*
+</Changed>
+
+<Deprecated>
+  - **IngestPipeline `ingest` parameter** — The `ingest` parameter in IngestPipeline configurations is deprecated:
+    - **TypeScript**: Use `ingestAPI` instead of `ingest`
+    - **Python**: Use `ingest_api` instead of `ingest`
+    
+    The old parameter will be removed in a future major version. Please update your code to use the new parameter names. *[Current PR]*
+</Deprecated>
+
+<BreakingChanges>
+  None - Full backwards compatibility maintained
+</BreakingChanges>
+
+---
 ## 2025-06-12
 
 <ReleaseHighlights>

--- a/apps/framework-docs/src/pages/moose/data-modeling.mdx
+++ b/apps/framework-docs/src/pages/moose/data-modeling.mdx
@@ -125,7 +125,7 @@ interface MyDataModel {
 
 // This single interface can be reused across multiple systems:
 const pipeline = new IngestPipeline<MyDataModel>("MyDataPipeline", {
-  ingest: true,    // POST API endpoint
+  ingestApi: true,    // POST API endpoint
   stream: true,    // Kafka topic
   table: {         // ClickHouse table
     orderByFields: ["primaryKey", "someDate"]
@@ -146,7 +146,7 @@ class MyFirstDataModel(BaseModel):
 
 # This single model can be reused across multiple systems:
 my_first_pipeline = IngestPipeline[MyFirstDataModel]("my_first_pipeline", IngestPipelineConfig(
-    ingest=True,  # POST API endpoint
+    ingest_api=True,  # POST API endpoint
     stream=True,  # Kafka topic
     table=True    # ClickHouse table
 ))
@@ -275,7 +275,7 @@ export interface SimpleShared {
 
 // This SAME model creates all infrastructure
 const pipeline = new IngestPipeline<SimpleShared>("simple_shared", {
-  ingest: true,  // Creates: POST /ingest/simple_shared
+  ingestApi: true,  // Creates: POST /ingest/simple_shared
   stream: true,  // Creates: Kafka topic
   table: true    // Creates: ClickHouse table
 });
@@ -300,7 +300,7 @@ class SimpleShared(BaseModel):
 
 # This SAME model creates all infrastructure
 pipeline = IngestPipeline[SimpleShared]("simple_shared", IngestPipelineConfig(
-    ingest=True,  # Creates: POST /ingest/simple_shared
+    ingest_api=True,  # Creates: POST /ingest/simple_shared
     stream=True,  # Creates: Kafka topic
     table=True    # Creates: ClickHouse table
 ))
@@ -344,7 +344,7 @@ export interface CompositeShared {
 
 // Using in IngestPipeline - all types preserved
 const pipeline = new IngestPipeline<CompositeShared>("composite_shared", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true
 });
@@ -392,7 +392,7 @@ class CompositeShared(BaseModel):
 
 # Using in IngestPipeline - all types preserved
 pipeline = IngestPipeline[CompositeShared]("composite_shared", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
@@ -449,7 +449,7 @@ const table = new OlapTable<ClickHouseOptimized>("optimized_table", {
 
 // SCENARIO 2: IngestPipeline - optimizations ONLY in ClickHouse
 const pipeline = new IngestPipeline<ClickHouseOptimized>("optimized_pipeline", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true
 });
@@ -500,7 +500,7 @@ table = OlapTable[ClickHouseOptimized]("optimized_table", {
 
 # SCENARIO 2: IngestPipeline - optimizations ONLY in ClickHouse
 pipeline = IngestPipeline[ClickHouseOptimized]("optimized_pipeline", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))

--- a/apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx
+++ b/apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx
@@ -123,7 +123,7 @@ const productAnalytics = new IngestPipeline<ProductEvent>("product_analytics", {
   stream: {
     parallelism: 4,
   },
-  ingest: true,
+  ingestApi: true,
   // automatically applied to the table and stream
   lifeCycle: LifeCycle.DELETION_PROTECTED
 });
@@ -150,7 +150,7 @@ product_analytics = IngestPipeline[ProductEvent]("product_analytics", IngestPipe
     stream=StreamConfig(
         parallelism=4,
     ),
-    ingest=True,
+    ingest_api=True,
   # automatically applied to the table and stream
   life_cycle=LifeCycle.DELETION_PROTECTED
 ))

--- a/apps/framework-docs/src/pages/moose/olap/insert-data.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/insert-data.mdx
@@ -179,9 +179,9 @@ const eventsPipeline = new IngestPipeline<Event>("user_events", {
 
 <Python>
 ```py filename="IngestPipeline.py" copy
-from moose_lib import IngestPipeline, IngestConfig
+from moose_lib import IngestPipeline, IngestPipelineConfig
 
-ingest_pipeline = IngestPipeline[Event]("user_events", IngestConfig(
+ingest_pipeline = IngestPipeline[Event]("user_events", IngestPipelineConfig(
     ingest_api=True,
     stream=True,
     table=True,

--- a/apps/framework-docs/src/pages/moose/olap/insert-data.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/insert-data.mdx
@@ -167,7 +167,7 @@ Alternatively, use `IngestPipeline` instead of standalone `IngestApi`, `Stream` 
 import { IngestPipeline } from "@514labs/moose-lib";
 
 const eventsPipeline = new IngestPipeline<Event>("user_events", {
-   ingest: true,
+   ingestApi: true,
    stream: true,
    table: {
     orderByFields: ["id", "timestamp"],
@@ -182,7 +182,7 @@ const eventsPipeline = new IngestPipeline<Event>("user_events", {
 from moose_lib import IngestPipeline, IngestConfig
 
 ingest_pipeline = IngestPipeline[Event]("user_events", IngestConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
 ))

--- a/apps/framework-docs/src/pages/moose/olap/model-table.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-table.mdx
@@ -153,7 +153,7 @@ interface UserEvent {
 
 // Create a complete ingestion pipeline with a table
 const eventsPipeline = new IngestPipeline<UserEvent>("user_events", {
-  ingestAPI: true,    // Creates a REST API endpoint at POST localhost:4000/ingest/user_events
+  ingestApi: true,    // Creates a REST API endpoint at POST localhost:4000/ingest/user_events
   stream: true,    // Creates Kafka/Redpanda topic
   table: {         // Creates and configures the table named "user_events"
     orderByFields: ["id", "timestamp"]

--- a/apps/framework-docs/src/pages/moose/olap/model-table.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/model-table.mdx
@@ -153,7 +153,7 @@ interface UserEvent {
 
 // Create a complete ingestion pipeline with a table
 const eventsPipeline = new IngestPipeline<UserEvent>("user_events", {
-  ingest: true,    // Creates a REST API endpoint at POST localhost:4000/ingest/user_events
+  ingestAPI: true,    // Creates a REST API endpoint at POST localhost:4000/ingest/user_events
   stream: true,    // Creates Kafka/Redpanda topic
   table: {         // Creates and configures the table named "user_events"
     orderByFields: ["id", "timestamp"]
@@ -180,7 +180,7 @@ from moose_lib import IngestPipeline, IngestPipelineConfig, OlapConfig
 from moose_lib.blocks import ReplacingMergeTreeEngine
 
 events_pipeline = IngestPipeline[UserEvent]("user_events", IngestPipelineConfig(
-  ingest=True, # Creates a REST API endpoint at POST localhost:4000/ingest/user_events
+  ingest_api=True, # Creates a REST API endpoint at POST localhost:4000/ingest/user_events
   stream=True, # Creates a Kafka/Redpanda topic
   table=OlapConfig(      # Creates and configures the table named "user_events"
     order_by_fields=["id", "timestamp"],

--- a/apps/framework-docs/src/pages/moose/reference/py-moose-lib.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/py-moose-lib.mdx
@@ -113,7 +113,7 @@ Configuration for creating a complete data pipeline.
 class IngestPipelineConfig(BaseModel):
     table: bool | OlapConfig = True
     stream: bool | StreamConfig = True
-    ingest: bool | IngestConfig = True
+    ingest_api: bool | IngestConfig = True
 ```
 
 ## Infrastructure Components
@@ -189,14 +189,14 @@ from moose_lib.blocks import ReplacingMergeTreeEngine
 
 # Basic usage
 pipeline = IngestPipeline[UserEvent]("user_pipeline", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
 
 # With advanced configuration
 pipeline = IngestPipeline[UserEvent]("user_pipeline", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=StreamConfig(parallelism=3),
     table=OlapConfig(
         order_by_fields=["id", "timestamp"],

--- a/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
@@ -110,14 +110,14 @@ Combines ingest API, stream, and table creation in a single component.
 ```ts
 // Basic usage
 export const pipeline = new IngestPipeline<UserEvent>("user_pipeline", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true
 });
 
 // With advanced configuration
 export const advancedPipeline = new IngestPipeline<UserEvent>("advanced_pipeline", {
-  ingest: true,
+  ingestApi: true,
   stream: { parallelism: 3 },
   table: { 
     orderByFields: ["id", "timestamp"]

--- a/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
@@ -56,7 +56,7 @@ interface RawData {
 }
 
 export const rawIngestionStream = new IngestPipeline<RawData>("raw_data", {
-  ingestAPI: true, // Creates an ingestion API endpoint at `POST /ingest/raw_data`
+  ingestApi: true, // Creates an ingestion API endpoint at `POST /ingest/raw_data`
   stream: true, // Buffers data between the ingestion API and the database table
   table: true // Creates an OLAP table named `raw_data`
 });
@@ -171,14 +171,14 @@ interface TransformedData {
 
 // Configure components for raw data ingestion & buffering
 const rawData = new IngestPipeline<RawData>("raw_data", {
-  ingestAPI: true,
+  ingestApi: true,
   stream: true, // Buffers data between the ingestion API and the database table
   table: false // Don't create a table for the raw data
 });
 
 // Create a table for the transformed data
 const transformedData = new IngestPipeline<TransformedData>("transformed_data", {
-  ingestAPI: false, // Don't create an ingestion API for the transformed data
+  ingestApi: false, // Don't create an ingestion API for the transformed data
   stream: true, // Create destination stream for the transformed data
   table: true // Create a table for the transformed data
 });
@@ -353,7 +353,7 @@ interface FinalData {
 // Create the first pipeline for raw data ingestion
 // Only create an API and a stream (no table) since we're ingesting the raw data
 const rawData = new IngestPipeline<RawData>("raw_data", {
-  ingestAPI: true,   // Enable HTTP ingestion endpoint
+  ingestApi: true,   // Enable HTTP ingestion endpoint
   stream: true,   // Create a stream to buffer data
   table: false    // Don't store raw data in a table
 });
@@ -370,7 +370,7 @@ rawData.stream.addTransform(intermediateStream, (record) => ({
 
 // Create the final pipeline that will store the fully transformed data
 const finalData = new IngestPipeline<FinalData>("final_stream", {
-  ingestAPI: false,  // No direct ingestion to this pipeline
+  ingestApi: false,  // No direct ingestion to this pipeline
   stream: true,   // Create a stream for processing
   table: true     // Store final results in a table
 });

--- a/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/create-stream.mdx
@@ -56,7 +56,7 @@ interface RawData {
 }
 
 export const rawIngestionStream = new IngestPipeline<RawData>("raw_data", {
-  ingestApi: true, // Creates an ingestion API endpoint at `POST /ingest/raw_data`
+  ingestAPI: true, // Creates an ingestion API endpoint at `POST /ingest/raw_data`
   stream: true, // Buffers data between the ingestion API and the database table
   table: true // Creates an OLAP table named `raw_data`
 });
@@ -171,14 +171,14 @@ interface TransformedData {
 
 // Configure components for raw data ingestion & buffering
 const rawData = new IngestPipeline<RawData>("raw_data", {
-  ingestApi: true,
+  ingestAPI: true,
   stream: true, // Buffers data between the ingestion API and the database table
   table: false // Don't create a table for the raw data
 });
 
 // Create a table for the transformed data
 const transformedData = new IngestPipeline<TransformedData>("transformed_data", {
-  ingestApi: false, // Don't create an ingestion API for the transformed data
+  ingestAPI: false, // Don't create an ingestion API for the transformed data
   stream: true, // Create destination stream for the transformed data
   table: true // Create a table for the transformed data
 });
@@ -353,7 +353,7 @@ interface FinalData {
 // Create the first pipeline for raw data ingestion
 // Only create an API and a stream (no table) since we're ingesting the raw data
 const rawData = new IngestPipeline<RawData>("raw_data", {
-  ingestApi: true,   // Enable HTTP ingestion endpoint
+  ingestAPI: true,   // Enable HTTP ingestion endpoint
   stream: true,   // Create a stream to buffer data
   table: false    // Don't store raw data in a table
 });
@@ -370,7 +370,7 @@ rawData.stream.addTransform(intermediateStream, (record) => ({
 
 // Create the final pipeline that will store the fully transformed data
 const finalData = new IngestPipeline<FinalData>("final_stream", {
-  ingestApi: false,  // No direct ingestion to this pipeline
+  ingestAPI: false,  // No direct ingestion to this pipeline
   stream: true,   // Create a stream for processing
   table: true     // Store final results in a table
 });

--- a/apps/framework-docs/src/pages/moose/streaming/dead-letter-queues.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/dead-letter-queues.mdx
@@ -534,7 +534,7 @@ interface ExampleSchema {
 }
 
 const pipeline = new IngestPipeline<ExampleSchema>("example", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true,
   deadLetterQueue: true, // Route failed ingestions to DLQ
@@ -558,7 +558,7 @@ example_dlq = DeadLetterQueue[ExampleSchema](name="exampleDLQ")
 pipeline = IngestPipeline[ExampleSchema](
     name="example",
     config=IngestPipelineConfig(
-        ingest=True,
+        ingest_api=True,
         stream=True,
         table=True,
         dead_letter_queue=True  # Route failed ingestions to DLQ

--- a/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
@@ -20,9 +20,9 @@ The most common way to publish data is through Moose's built-in ingestion APIs. 
 
 <TypeScript>
 ```typescript filename="PublishViaAPI.ts"
-// When you create an IngestPipeline with ingest: true, Moose automatically creates an API endpoint
+// When you create an IngestPipeline with ingestApi: true, Moose automatically creates an API endpoint
 const rawData = new IngestPipeline<RawData>("raw_data", {
-  ingest: true, // Creates POST /ingest/raw_data endpoint
+  ingestApi: true, // Creates POST /ingest/raw_data endpoint
   stream: true,
   table: true
 });

--- a/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
@@ -44,13 +44,14 @@ const response = await fetch('/ingest/raw_data', {
 <Python>
 ```py filename="PublishViaAPI.py" copy
 import requests
+from moose_lib import IngestPipeline, IngestPipelineConfig
 
-# When you create an IngestPipeline with ingest: True, Moose automatically creates an API endpoint
-raw_data = IngestPipeline[RawData]("raw_data", {
-  ingest: True, # Creates POST /ingest/raw_data endpoint
-  stream: True,
-  table: True
-})
+# When you create an IngestPipeline with ingest_api: True, Moose automatically creates an API endpoint
+raw_data = IngestPipeline[RawData]("raw_data", IngestPipelineConfig(
+  ingest_api=True, # Creates POST /ingest/raw_data endpoint
+  stream=True,
+  table=True
+))
 
 # You can then publish data via HTTP POST requests
 response = requests.post('/ingest/raw_data', json={

--- a/apps/framework-docs/src/pages/moose/streaming/sync-to-table.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/sync-to-table.mdx
@@ -94,7 +94,7 @@ interface Event {
 
 // Creates stream, table, API, and automatic sync
 const eventsPipeline = new IngestPipeline<Event>("events", {
-  ingest: true,   // Creates HTTP endpoint at POST /ingest/events
+  ingestApi: true,   // Creates HTTP endpoint at POST /ingest/events
   stream: true,   // Creates buffering stream
   table: true     // Creates destination table + auto-sync process
 });
@@ -115,7 +115,7 @@ class Event(BaseModel):
 
 # Creates stream, table, API, and automatic sync
 events_pipeline = IngestPipeline[Event]("events", IngestPipelineConfig(
-    ingest=True,   
+    ingest_api=True,   
     stream=True,   # Creates stream  
     table=True     # Creates destination table + auto-sync process
 ))

--- a/apps/framework-docs/src/pages/moose/streaming/transform-functions.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/transform-functions.mdx
@@ -493,13 +493,13 @@ interface ProcessedEvent {
 
 // Create pipelines
 const rawEvents = new IngestPipeline<UserEvent>("raw_events", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: false
 });
 
 const processedEvents = new IngestPipeline<ProcessedEvent>("processed_events", {
-  ingest: false,
+  ingestApi: false,
   stream: true,
   table: true
 });

--- a/apps/framework-docs/src/pages/moose/streaming/transform-functions.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/transform-functions.mdx
@@ -542,7 +542,7 @@ eventDLQ.addConsumer((deadLetter) => {
 
 <Python>
 ```py filename="DeadLetterQueue.py" copy
-from moose_lib import DeadLetterQueue, IngestPipeline, TransformConfig, DeadLetterModel
+from moose_lib import DeadLetterQueue, IngestPipeline, IngestPipelineConfig, TransformConfig, DeadLetterModel
 from pydantic import BaseModel
 from datetime import datetime
 
@@ -558,17 +558,17 @@ class ProcessedEvent(BaseModel):
     is_valid: bool
 
 # Create pipelines
-raw_events = IngestPipeline[UserEvent]("raw_events", {
-    "ingest": True,
-    "stream": True,
-    "table": False
-})
+raw_events = IngestPipeline[UserEvent]("raw_events", IngestPipelineConfig(
+    ingest_api=True,
+    stream=True,
+    table=False
+))
 
-processed_events = IngestPipeline[ProcessedEvent]("processed_events", {
-    "ingest": False,
-    "stream": True,
-    "table": True
-})
+processed_events = IngestPipeline[ProcessedEvent]("processed_events", IngestPipelineConfig(
+    ingest_api=False,
+    stream=True,
+    table=True
+))
 
 # Create dead letter queue for failed transformations
 event_dlq = DeadLetterQueue[UserEvent](name="EventDLQ")

--- a/apps/framework-docs/src/pages/sloan/guides/clickhouse-proj.mdx
+++ b/apps/framework-docs/src/pages/sloan/guides/clickhouse-proj.mdx
@@ -137,7 +137,7 @@ const acPipeline = new IngestPipeline<AircraftTrackingProcessed>(
     {
       table: true,
       stream: true,
-      ingest: false,
+      ingestApi: false,
       metadata: {
           description: "Pipeline for ingesting raw aircraft data" } // new description field!
       }

--- a/apps/framework-docs/src/pages/sloan/guides/from-template.mdx
+++ b/apps/framework-docs/src/pages/sloan/guides/from-template.mdx
@@ -82,7 +82,7 @@ const acPipeline = new IngestPipeline<AircraftTrackingProcessed>(
     {
       table: true,
       stream: true,
-      ingest: false,
+      ingestApi: false,
       metadata: {
           description: "Pipeline for ingesting raw aircraft data" } // new description field!
       }

--- a/apps/framework-docs/src/pages/sloan/reference/tool-reference.mdx
+++ b/apps/framework-docs/src/pages/sloan/reference/tool-reference.mdx
@@ -457,7 +457,7 @@ export interface AircraftTrackingData {
 // Define ingest pipelines
 export const AircraftTrackingDataPipeline = new IngestPipeline<AircraftTrackingData>(
   "AircraftTrackingData", 
-  { table: false, stream: true, ingest: true }
+  { table: false, stream: true, ingestApi: true }
 );
 ```
 

--- a/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
@@ -24,7 +24,7 @@ class IngestPipelineConfig(BaseModel):
     Attributes:
         table: Configuration for the OLAP table component.
         stream: Configuration for the stream component.
-        ingest: Configuration for the ingest API component.
+        ingest_api: Configuration for the ingest API component.
         dead_letter_queue: Configuration for the dead letter queue.
         version: Optional version string applied to all created components.
         path: Optional custom path for the ingestion API endpoint.
@@ -33,7 +33,7 @@ class IngestPipelineConfig(BaseModel):
     """
     table: bool | OlapConfig = True
     stream: bool | StreamConfig = True
-    ingest: bool | IngestConfig = True
+    ingest_api: bool | IngestConfig = True
     dead_letter_queue: bool | StreamConfig = True
     version: Optional[str] = None
     path: Optional[str] = None
@@ -173,11 +173,11 @@ class IngestPipeline(TypedMooseResource, Generic[T]):
                 stream_config.version = config.version
             stream_config.metadata = stream_metadata
             self.stream = Stream(name, stream_config, t=self._t)
-        if config.ingest:
+        if config.ingest_api:
             if self.stream is None:
                 raise ValueError("Ingest API needs a stream to write to.")
             ingest_config_dict = (
-                IngestConfig() if config.ingest is True else config.ingest
+                IngestConfig() if config.ingest_api is True else config.ingest_api
             ).model_dump()
             ingest_config_dict["destination"] = self.stream
             if config.version:

--- a/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
@@ -4,8 +4,9 @@ Ingestion Pipeline definitions for Moose Data Model v2 (dmv2).
 This module provides classes for defining and configuring complete ingestion pipelines,
 which combine tables, streams, and ingestion APIs into a single cohesive unit.
 """
+import warnings
 from typing import Any, Optional, Generic, TypeVar
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from .types import TypedMooseResource, T
 from .olap_table import OlapTable, OlapConfig
@@ -38,6 +39,28 @@ class IngestPipelineConfig(BaseModel):
     path: Optional[str] = None
     metadata: Optional[dict] = None
     life_cycle: Optional[LifeCycle] = None
+    
+    # Legacy support - will be removed in future version
+    ingest: Optional[bool | IngestConfig] = None
+    
+    @model_validator(mode='before')
+    @classmethod
+    def handle_legacy_ingest_param(cls, data):
+        """Handle backwards compatibility for the deprecated 'ingest' parameter."""
+        if isinstance(data, dict) and 'ingest' in data:
+            warnings.warn(
+                "The 'ingest' parameter is deprecated and will be removed in a future version. "
+                "Please use 'ingest_api' instead.",
+                DeprecationWarning,
+                stacklevel=3
+            )
+            # If ingest_api is not explicitly set, use the ingest value
+            if 'ingest_api' not in data:
+                data['ingest_api'] = data['ingest']
+            # Remove the legacy parameter
+            data = data.copy()
+            del data['ingest']
+        return data
 
 class IngestPipeline(TypedMooseResource, Generic[T]):
     """Creates and configures a linked Table, Stream, and Ingest API pipeline.

--- a/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
@@ -54,11 +54,12 @@ class IngestPipelineConfig(BaseModel):
                 DeprecationWarning,
                 stacklevel=3
             )
+            # Make a copy first to avoid mutating the original dictionary
+            data = data.copy()
             # If ingest_api is not explicitly set, use the ingest value
             if 'ingest_api' not in data:
                 data['ingest_api'] = data['ingest']
             # Remove the legacy parameter
-            data = data.copy()
             del data['ingest']
         return data
 

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -23,14 +23,14 @@ import { ClickHouseEngines } from "../../blocks/helpers";
  * const pipelineConfig: IngestPipelineConfig<UserData> = {
  *   table: true,
  *   stream: true,
- *   ingestAPI: true
+ *   ingestApi: true
  * };
  *
  * // Advanced pipeline with custom configurations
  * const advancedConfig: IngestPipelineConfig<UserData> = {
  *   table: { orderByFields: ['timestamp', 'userId'], engine: ClickHouseEngines.ReplacingMergeTree },
  *   stream: { parallelism: 4, retentionPeriod: 86400 },
- *   ingestAPI: true,
+ *   ingestApi: true,
  *   version: '1.2.0',
  *   metadata: { description: 'User data ingestion pipeline' }
  * };
@@ -72,10 +72,10 @@ export type IngestPipelineConfig<T> = {
    *
    * @default false
    */
-  ingestAPI: boolean | Omit<IngestConfig<T>, "destination">;
+  ingestApi: boolean | Omit<IngestConfig<T>, "destination">;
 
   /**
-   * @deprecated Use `ingestAPI` instead. This parameter will be removed in a future version.
+   * @deprecated Use `ingestApi` instead. This parameter will be removed in a future version.
    */
   ingest?: boolean | Omit<IngestConfig<T>, "destination">;
 
@@ -134,7 +134,7 @@ export type IngestPipelineConfig<T> = {
  * const userDataPipeline = new IngestPipeline('userData', {
  *   table: true,
  *   stream: true,
- *   ingestAPI: true,
+ *   ingestApi: true,
  *   version: '1.0.0',
  *   metadata: { description: 'Pipeline for user registration data' }
  * });
@@ -143,7 +143,7 @@ export type IngestPipelineConfig<T> = {
  * const analyticsStream = new IngestPipeline('analytics', {
  *   table: { orderByFields: ['timestamp'], engine: ClickHouseEngines.ReplacingMergeTree },
  *   stream: { parallelism: 8, retentionPeriod: 604800 },
- *   ingestAPI: false
+ *   ingestApi: false
  * });
  * ```
  */
@@ -165,7 +165,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
   /**
    * The ingest API component of the pipeline, if configured.
    * Provides HTTP endpoints for data ingestion.
-   * Only present when `config.ingestAPI` is not `false`.
+   * Only present when `config.ingestApi` is not `false`.
    */
   ingestApi?: IngestApi<T>;
 
@@ -186,7 +186,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
    * const pipeline = new IngestPipeline('events', {
    *   table: { orderByFields: ['timestamp'], engine: ClickHouseEngines.ReplacingMergeTree },
    *   stream: { parallelism: 2 },
-   *   ingestAPI: true
+   *   ingestApi: true
    * });
    * ```
    */
@@ -222,11 +222,11 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
     if (config.ingest !== undefined) {
       console.warn(
         "⚠️  DEPRECATION WARNING: The 'ingest' parameter is deprecated and will be removed in a future version. " +
-          "Please use 'ingestAPI' instead.",
+          "Please use 'ingestApi' instead.",
       );
-      // If ingestAPI is not explicitly set, use the ingest value
-      if (config.ingestAPI === undefined) {
-        (config as any).ingestAPI = config.ingest;
+      // If ingestApi is not explicitly set, use the ingest value
+      if (config.ingestApi === undefined) {
+        (config as any).ingestApi = config.ingest;
       }
     }
 
@@ -289,7 +289,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
 
     // Create ingest API if configured, requiring a stream as destination
     const effectiveIngestAPI =
-      config.ingestAPI !== undefined ? config.ingestAPI : config.ingest;
+      config.ingestApi !== undefined ? config.ingestApi : config.ingest;
     if (effectiveIngestAPI) {
       if (!this.stream) {
         throw new Error("Ingest API needs a stream to write to.");

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -288,9 +288,9 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
     }
 
     // Create ingest API if configured, requiring a stream as destination
-    const shouldCreateIngestAPI =
-      config.ingestAPI || (config.ingest && !config.ingestAPI);
-    if (shouldCreateIngestAPI) {
+    const effectiveIngestAPI =
+      config.ingestAPI !== undefined ? config.ingestAPI : config.ingest;
+    if (effectiveIngestAPI) {
       if (!this.stream) {
         throw new Error("Ingest API needs a stream to write to.");
       }
@@ -298,8 +298,8 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
       const ingestConfig = {
         destination: this.stream,
         deadLetterQueue: this.deadLetterQueue,
-        ...(typeof (config.ingestAPI || config.ingest) === "object" ?
-          ((config.ingestAPI || config.ingest) as object)
+        ...(typeof effectiveIngestAPI === "object" ?
+          (effectiveIngestAPI as object)
         : {}),
         ...(config.version && { version: config.version }),
         ...(config.path && { path: config.path }),

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -23,14 +23,14 @@ import { ClickHouseEngines } from "../../blocks/helpers";
  * const pipelineConfig: IngestPipelineConfig<UserData> = {
  *   table: true,
  *   stream: true,
- *   ingest: true
+ *   ingestAPI: true
  * };
  *
  * // Advanced pipeline with custom configurations
  * const advancedConfig: IngestPipelineConfig<UserData> = {
  *   table: { orderByFields: ['timestamp', 'userId'], engine: ClickHouseEngines.ReplacingMergeTree },
  *   stream: { parallelism: 4, retentionPeriod: 86400 },
- *   ingest: true,
+ *   ingestAPI: true,
  *   version: '1.2.0',
  *   metadata: { description: 'User data ingestion pipeline' }
  * };
@@ -72,7 +72,7 @@ export type IngestPipelineConfig<T> = {
    *
    * @default false
    */
-  ingest: boolean | Omit<IngestConfig<T>, "destination">;
+  ingestAPI: boolean | Omit<IngestConfig<T>, "destination">;
 
   /**
    * Configuration for the dead letter queue of the pipeline.
@@ -129,7 +129,7 @@ export type IngestPipelineConfig<T> = {
  * const userDataPipeline = new IngestPipeline('userData', {
  *   table: true,
  *   stream: true,
- *   ingest: true,
+ *   ingestAPI: true,
  *   version: '1.0.0',
  *   metadata: { description: 'Pipeline for user registration data' }
  * });
@@ -138,7 +138,7 @@ export type IngestPipelineConfig<T> = {
  * const analyticsStream = new IngestPipeline('analytics', {
  *   table: { orderByFields: ['timestamp'], engine: ClickHouseEngines.ReplacingMergeTree },
  *   stream: { parallelism: 8, retentionPeriod: 604800 },
- *   ingest: false
+ *   ingestAPI: false
  * });
  * ```
  */
@@ -160,7 +160,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
   /**
    * The ingest API component of the pipeline, if configured.
    * Provides HTTP endpoints for data ingestion.
-   * Only present when `config.ingest` is not `false`.
+   * Only present when `config.ingestAPI` is not `false`.
    */
   ingestApi?: IngestApi<T>;
 
@@ -181,7 +181,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
    * const pipeline = new IngestPipeline('events', {
    *   table: { orderByFields: ['timestamp'], engine: ClickHouseEngines.ReplacingMergeTree },
    *   stream: { parallelism: 2 },
-   *   ingest: true
+   *   ingestAPI: true
    * });
    * ```
    */
@@ -271,7 +271,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
     }
 
     // Create ingest API if configured, requiring a stream as destination
-    if (config.ingest) {
+    if (config.ingestAPI) {
       if (!this.stream) {
         throw new Error("Ingest API needs a stream to write to.");
       }
@@ -279,7 +279,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
       const ingestConfig = {
         destination: this.stream,
         deadLetterQueue: this.deadLetterQueue,
-        ...(typeof config.ingest === "object" ? config.ingest : {}),
+        ...(typeof config.ingestAPI === "object" ? config.ingestAPI : {}),
         ...(config.version && { version: config.version }),
         ...(config.path && { path: config.path }),
       };

--- a/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/ingestPipeline.ts
@@ -225,7 +225,7 @@ export class IngestPipeline<T> extends TypedBase<T, IngestPipelineConfig<T>> {
           "Please use 'ingestAPI' instead.",
       );
       // If ingestAPI is not explicitly set, use the ingest value
-      if (config.ingestAPI === undefined || config.ingestAPI === false) {
+      if (config.ingestAPI === undefined) {
         (config as any).ingestAPI = config.ingest;
       }
     }

--- a/templates/ads-b-frontend/moose/app/datamodels/models.ts
+++ b/templates/ads-b-frontend/moose/app/datamodels/models.ts
@@ -72,12 +72,12 @@ export const AircraftTrackingDataPipeline =
   new IngestPipeline<AircraftTrackingData>("AircraftTrackingData", {
     table: false,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   });
 
 export const AircraftTrackingProcessedPipeline =
   new IngestPipeline<AircraftTrackingProcessed>("AircraftTrackingProcessed", {
     table: true,
     stream: true,
-    ingestAPI: false,
+    ingestApi: false,
   });

--- a/templates/ads-b-frontend/moose/app/datamodels/models.ts
+++ b/templates/ads-b-frontend/moose/app/datamodels/models.ts
@@ -72,12 +72,12 @@ export const AircraftTrackingDataPipeline =
   new IngestPipeline<AircraftTrackingData>("AircraftTrackingData", {
     table: false,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   });
 
 export const AircraftTrackingProcessedPipeline =
   new IngestPipeline<AircraftTrackingProcessed>("AircraftTrackingProcessed", {
     table: true,
     stream: true,
-    ingest: false,
+    ingestAPI: false,
   });

--- a/templates/ads-b/app/datamodels/models.ts
+++ b/templates/ads-b/app/datamodels/models.ts
@@ -72,12 +72,12 @@ export const AircraftTrackingDataPipeline =
   new IngestPipeline<AircraftTrackingData>("AircraftTrackingData", {
     table: false,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   });
 
 export const AircraftTrackingProcessedPipeline =
   new IngestPipeline<AircraftTrackingProcessed>("AircraftTrackingProcessed", {
     table: true,
     stream: true,
-    ingestAPI: false,
+    ingestApi: false,
   });

--- a/templates/ads-b/app/datamodels/models.ts
+++ b/templates/ads-b/app/datamodels/models.ts
@@ -72,12 +72,12 @@ export const AircraftTrackingDataPipeline =
   new IngestPipeline<AircraftTrackingData>("AircraftTrackingData", {
     table: false,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   });
 
 export const AircraftTrackingProcessedPipeline =
   new IngestPipeline<AircraftTrackingProcessed>("AircraftTrackingProcessed", {
     table: true,
     stream: true,
-    ingest: false,
+    ingestAPI: false,
   });

--- a/templates/brainwaves/apps/brainmoose/app/datamodels/brain.ts
+++ b/templates/brainwaves/apps/brainmoose/app/datamodels/brain.ts
@@ -37,5 +37,5 @@ export const BrainPipeline = new IngestPipeline<Brain>("Brain", {
     orderByFields: ["sessionId", "timestamp"],
   },
   stream: true,
-  ingest: true, // POST /ingest/Brain
+  ingestAPI: true, // POST /ingest/Brain
 });

--- a/templates/brainwaves/apps/brainmoose/app/datamodels/brain.ts
+++ b/templates/brainwaves/apps/brainmoose/app/datamodels/brain.ts
@@ -37,5 +37,5 @@ export const BrainPipeline = new IngestPipeline<Brain>("Brain", {
     orderByFields: ["sessionId", "timestamp"],
   },
   stream: true,
-  ingestAPI: true, // POST /ingest/Brain
+  ingestApi: true, // POST /ingest/Brain
 });

--- a/templates/brainwaves/apps/brainmoose/app/datamodels/models.ts
+++ b/templates/brainwaves/apps/brainmoose/app/datamodels/models.ts
@@ -24,7 +24,7 @@ export const UserActivityPipeline = new IngestPipeline<UserActivity>(
       engine: ClickHouseEngines.ReplacingMergeTree,
     },
     stream: true,
-    ingestAPI: true, // POST /ingest/UserActivity
+    ingestApi: true, // POST /ingest/UserActivity
   },
 );
 
@@ -37,6 +37,6 @@ export const ParsedActivityPipeline = new IngestPipeline<ParsedActivity>(
       engine: ClickHouseEngines.ReplacingMergeTree,
     },
     stream: true,
-    ingestAPI: false, // No direct ingest API; populated by streaming function
+    ingestApi: false, // No direct ingest API; populated by streaming function
   },
 );

--- a/templates/brainwaves/apps/brainmoose/app/datamodels/models.ts
+++ b/templates/brainwaves/apps/brainmoose/app/datamodels/models.ts
@@ -24,7 +24,7 @@ export const UserActivityPipeline = new IngestPipeline<UserActivity>(
       engine: ClickHouseEngines.ReplacingMergeTree,
     },
     stream: true,
-    ingest: true, // POST /ingest/UserActivity
+    ingestAPI: true, // POST /ingest/UserActivity
   },
 );
 
@@ -37,6 +37,6 @@ export const ParsedActivityPipeline = new IngestPipeline<ParsedActivity>(
       engine: ClickHouseEngines.ReplacingMergeTree,
     },
     stream: true,
-    ingest: false, // No direct ingest API; populated by streaming function
+    ingestAPI: false, // No direct ingest API; populated by streaming function
   },
 );

--- a/templates/github-dev-trends/packages/moose-objects/src/index.ts
+++ b/templates/github-dev-trends/packages/moose-objects/src/index.ts
@@ -14,14 +14,14 @@ import {
 
 // Pipeline to receive raw events from the Github API
 export const GhEvent = new IngestPipeline<IGhEvent>("GhEvent", {
-  ingestAPI: true,
+  ingestApi: true,
   table: true,
   stream: true,
 });
 
 // Pipeline to receive transformed events from the GhEvent pipeline
 export const RepoStarEvent = new IngestPipeline<IRepoStarEvent>("RepoStar", {
-  ingestAPI: false,
+  ingestApi: false,
   stream: true,
   table: true,
 });

--- a/templates/github-dev-trends/packages/moose-objects/src/index.ts
+++ b/templates/github-dev-trends/packages/moose-objects/src/index.ts
@@ -14,14 +14,14 @@ import {
 
 // Pipeline to receive raw events from the Github API
 export const GhEvent = new IngestPipeline<IGhEvent>("GhEvent", {
-  ingest: true,
+  ingestAPI: true,
   table: true,
   stream: true,
 });
 
 // Pipeline to receive transformed events from the GhEvent pipeline
 export const RepoStarEvent = new IngestPipeline<IRepoStarEvent>("RepoStar", {
-  ingest: false,
+  ingestAPI: false,
   stream: true,
   table: true,
 });

--- a/templates/live-heartrate-leaderboard/app/pipelines/pipelines.py
+++ b/templates/live-heartrate-leaderboard/app/pipelines/pipelines.py
@@ -14,26 +14,26 @@ from app.functions.bluetooth_to_unified_packet import bluetoothHRPacket__UNIFIED
 
 # Initalize Ingest Pipeline Infrastructure
 rawAntHRPipeline = IngestPipeline[RawAntHRPacket]("raw_ant_hr_packet", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
 
 
 processedAntHRPipeline = IngestPipeline[ProcessedAntHRPacket]("processed_ant_hr_packet", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
 
 unifiedHRPipeline = IngestPipeline[UnifiedHRPacket]("unified_hr_packet", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
 
 bluetoothHRPipeline = IngestPipeline[BluetoothHRPacket]("bluetooth_hr_packet", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))

--- a/templates/python-tests/app/ingest/models.py
+++ b/templates/python-tests/app/ingest/models.py
@@ -29,14 +29,14 @@ class Bar(BaseModel):
 
 
 fooModel = IngestPipeline[Foo]("Foo", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=False,
     dead_letter_queue=True
 ))
 
 barModel = IngestPipeline[Bar]("Bar", IngestPipelineConfig(
-    ingest=False,
+    ingest_api=False,
     stream=True,
     table=True,
     dead_letter_queue=True
@@ -219,49 +219,49 @@ class EdgeCases(BaseModel):
 # =======Pipeline Configurations for Test Models=========
 
 basic_types_model = IngestPipeline[BasicTypes]("BasicTypes", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
 ))
 
 simple_arrays_model = IngestPipeline[SimpleArrays]("SimpleArrays", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
 ))
 
 nested_objects_model = IngestPipeline[NestedObjects]("NestedObjects", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
 ))
 
 arrays_of_objects_model = IngestPipeline[ArraysOfObjects]("ArraysOfObjects", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
 ))
 
 deeply_nested_arrays_model = IngestPipeline[DeeplyNestedArrays]("DeeplyNestedArrays", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
 ))
 
 mixed_complex_types_model = IngestPipeline[MixedComplexTypes]("MixedComplexTypes", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
 ))
 
 edge_cases_model = IngestPipeline[EdgeCases]("EdgeCases", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True
@@ -281,7 +281,7 @@ class OptionalNestedTest(BaseModel):
     other: Optional[Annotated[str, clickhouse_default("''")]] = None
 
 optional_nested_test_model = IngestPipeline[OptionalNestedTest]("OptionalNestedTest", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True,
     dead_letter_queue=True

--- a/templates/python/app/ingest/models.py
+++ b/templates/python/app/ingest/models.py
@@ -29,14 +29,14 @@ class Bar(BaseModel):
 
 
 fooModel = IngestPipeline[Foo]("Foo", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=False,
     dead_letter_queue=True
 ))
 
 barModel = IngestPipeline[Bar]("Bar", IngestPipelineConfig(
-    ingest=False,
+    ingest_api=False,
     stream=True,
     table=True,
     dead_letter_queue=True

--- a/templates/typescript-tests/app/ingest/models.ts
+++ b/templates/typescript-tests/app/ingest/models.ts
@@ -39,7 +39,7 @@ export const deadLetterTable = new OlapTable<DeadLetterModel>("FooDeadLetter", {
 export const FooPipeline = new IngestPipeline<Foo>("Foo", {
   table: false, // No table; only stream raw records
   stream: true, // Buffer ingested records
-  ingestAPI: true, // POST /ingest/Foo
+  ingestApi: true, // POST /ingest/Foo
   deadLetterQueue: {
     destination: deadLetterTable,
   },
@@ -49,7 +49,7 @@ export const FooPipeline = new IngestPipeline<Foo>("Foo", {
 export const BarPipeline = new IngestPipeline<Bar>("Bar", {
   table: true, // Persist in ClickHouse table "Bar"
   stream: true, // Buffer processed records
-  ingestAPI: false, // No API; only derive from processed Foo records
+  ingestApi: false, // No API; only derive from processed Foo records
 });
 
 /** =======Comprehensive Type Testing Data Models========= */
@@ -212,7 +212,7 @@ export interface EdgeCases {
 export const BasicTypesPipeline = new IngestPipeline<BasicTypes>("BasicTypes", {
   table: true,
   stream: true,
-  ingestAPI: true,
+  ingestApi: true,
 });
 
 export const SimpleArraysPipeline = new IngestPipeline<SimpleArrays>(
@@ -220,7 +220,7 @@ export const SimpleArraysPipeline = new IngestPipeline<SimpleArrays>(
   {
     table: true,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   },
 );
 
@@ -229,7 +229,7 @@ export const NestedObjectsPipeline = new IngestPipeline<NestedObjects>(
   {
     table: true,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   },
 );
 
@@ -238,7 +238,7 @@ export const ArraysOfObjectsPipeline = new IngestPipeline<ArraysOfObjects>(
   {
     table: true,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   },
 );
 
@@ -246,7 +246,7 @@ export const DeeplyNestedArraysPipeline =
   new IngestPipeline<DeeplyNestedArrays>("DeeplyNestedArrays", {
     table: true,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   });
 
 export const MixedComplexTypesPipeline = new IngestPipeline<MixedComplexTypes>(
@@ -254,14 +254,14 @@ export const MixedComplexTypesPipeline = new IngestPipeline<MixedComplexTypes>(
   {
     table: true,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   },
 );
 
 export const EdgeCasesPipeline = new IngestPipeline<EdgeCases>("EdgeCases", {
   table: true,
   stream: true,
-  ingestAPI: true,
+  ingestApi: true,
 });
 
 /** =======Optional Nested Fields with ClickHouse Defaults Test========= */
@@ -283,5 +283,5 @@ export const OptionalNestedTestPipeline =
   new IngestPipeline<OptionalNestedTest>("OptionalNestedTest", {
     table: true,
     stream: true,
-    ingestAPI: true,
+    ingestApi: true,
   });

--- a/templates/typescript-tests/app/ingest/models.ts
+++ b/templates/typescript-tests/app/ingest/models.ts
@@ -39,7 +39,7 @@ export const deadLetterTable = new OlapTable<DeadLetterModel>("FooDeadLetter", {
 export const FooPipeline = new IngestPipeline<Foo>("Foo", {
   table: false, // No table; only stream raw records
   stream: true, // Buffer ingested records
-  ingest: true, // POST /ingest/Foo
+  ingestAPI: true, // POST /ingest/Foo
   deadLetterQueue: {
     destination: deadLetterTable,
   },
@@ -49,7 +49,7 @@ export const FooPipeline = new IngestPipeline<Foo>("Foo", {
 export const BarPipeline = new IngestPipeline<Bar>("Bar", {
   table: true, // Persist in ClickHouse table "Bar"
   stream: true, // Buffer processed records
-  ingest: false, // No API; only derive from processed Foo records
+  ingestAPI: false, // No API; only derive from processed Foo records
 });
 
 /** =======Comprehensive Type Testing Data Models========= */
@@ -212,7 +212,7 @@ export interface EdgeCases {
 export const BasicTypesPipeline = new IngestPipeline<BasicTypes>("BasicTypes", {
   table: true,
   stream: true,
-  ingest: true,
+  ingestAPI: true,
 });
 
 export const SimpleArraysPipeline = new IngestPipeline<SimpleArrays>(
@@ -220,7 +220,7 @@ export const SimpleArraysPipeline = new IngestPipeline<SimpleArrays>(
   {
     table: true,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   },
 );
 
@@ -229,7 +229,7 @@ export const NestedObjectsPipeline = new IngestPipeline<NestedObjects>(
   {
     table: true,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   },
 );
 
@@ -238,7 +238,7 @@ export const ArraysOfObjectsPipeline = new IngestPipeline<ArraysOfObjects>(
   {
     table: true,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   },
 );
 
@@ -246,7 +246,7 @@ export const DeeplyNestedArraysPipeline =
   new IngestPipeline<DeeplyNestedArrays>("DeeplyNestedArrays", {
     table: true,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   });
 
 export const MixedComplexTypesPipeline = new IngestPipeline<MixedComplexTypes>(
@@ -254,14 +254,14 @@ export const MixedComplexTypesPipeline = new IngestPipeline<MixedComplexTypes>(
   {
     table: true,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   },
 );
 
 export const EdgeCasesPipeline = new IngestPipeline<EdgeCases>("EdgeCases", {
   table: true,
   stream: true,
-  ingest: true,
+  ingestAPI: true,
 });
 
 /** =======Optional Nested Fields with ClickHouse Defaults Test========= */
@@ -283,5 +283,5 @@ export const OptionalNestedTestPipeline =
   new IngestPipeline<OptionalNestedTest>("OptionalNestedTest", {
     table: true,
     stream: true,
-    ingest: true,
+    ingestAPI: true,
   });

--- a/templates/typescript/app/ingest/models.ts
+++ b/templates/typescript/app/ingest/models.ts
@@ -38,7 +38,7 @@ export const deadLetterTable = new OlapTable<DeadLetterModel>("FooDeadLetter", {
 export const FooPipeline = new IngestPipeline<Foo>("Foo", {
   table: false, // No table; only stream raw records
   stream: true, // Buffer ingested records
-  ingest: true, // POST /ingest/Foo
+  ingestAPI: true, // POST /ingest/Foo
   deadLetterQueue: {
     destination: deadLetterTable,
   },
@@ -48,5 +48,5 @@ export const FooPipeline = new IngestPipeline<Foo>("Foo", {
 export const BarPipeline = new IngestPipeline<Bar>("Bar", {
   table: true, // Persist in ClickHouse table "Bar"
   stream: true, // Buffer processed records
-  ingest: false, // No API; only derive from processed Foo records
+  ingestAPI: false, // No API; only derive from processed Foo records
 });

--- a/templates/typescript/app/ingest/models.ts
+++ b/templates/typescript/app/ingest/models.ts
@@ -38,7 +38,7 @@ export const deadLetterTable = new OlapTable<DeadLetterModel>("FooDeadLetter", {
 export const FooPipeline = new IngestPipeline<Foo>("Foo", {
   table: false, // No table; only stream raw records
   stream: true, // Buffer ingested records
-  ingestAPI: true, // POST /ingest/Foo
+  ingestApi: true, // POST /ingest/Foo
   deadLetterQueue: {
     destination: deadLetterTable,
   },
@@ -48,5 +48,5 @@ export const FooPipeline = new IngestPipeline<Foo>("Foo", {
 export const BarPipeline = new IngestPipeline<Bar>("Bar", {
   table: true, // Persist in ClickHouse table "Bar"
   stream: true, // Buffer processed records
-  ingestAPI: false, // No API; only derive from processed Foo records
+  ingestApi: false, // No API; only derive from processed Foo records
 });


### PR DESCRIPTION
## Summary
- Rename `ingest` parameter to `ingestApi` (TypeScript) and `ingest_api` (Python) in IngestPipeline
- Maintain full backwards compatibility with deprecation warnings
- Update all documentation to use new parameter names

## Changes
- **TypeScript**: `ingest: true/false` → `ingestApi: true/false`  
- **Python**: `ingest=True/False` → `ingest_api=True/False`
- Added backwards compatibility with deprecation warnings
- Fixed override logic to respect explicit `ingestApi: false`
- Updated examples across docs, templates, and LLM docs
- Preserved historical examples in release notes

## Test plan
- [x] All existing tests pass
- [x] Backwards compatibility verified
- [x] Documentation updated consistently
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames IngestPipeline `ingest` to `ingestApi` (TS) / `ingest_api` (Py) with backward-compatible handling and updates all docs, examples, and templates.
> 
> - **SDKs**
>   - **TypeScript**: `IngestPipelineConfig` adds `ingestApi` (new) and legacy `ingest` (deprecated); constructor maps legacy to new and logs deprecation; pipeline uses `ingestApi` for API creation.
>   - **Python**: `IngestPipelineConfig` adds `ingest_api` (new) with model validator to map deprecated `ingest` and warn; pipeline uses `config.ingest_api` for API creation.
> - **Documentation & Examples**
>   - Replace `ingest` with `ingestApi`/`ingest_api` across `apps/framework-docs` (APIs, pipelines, streaming, OLAP, references) and LLM docs.
>   - Update code samples/templates in `templates/*` and tests to new param; fix minor sample syntax (commas/constructor usage) where touched.
> - **Changelog**
>   - Add entry noting rename, deprecation of old param, and full backward compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19241ba84047130753e73c5ddbef10ca7918aacc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->