### PR TITLE
IngestPipeline documentation updates and validator bug fix (Closes PM-452)

### DIFF
--- a/apps/framework-docs/llm-docs/python/ingest.md
+++ b/apps/framework-docs/llm-docs/python/ingest.md
@@ -45,7 +45,7 @@ For `IngestPipeline`, configuration must be provided as keyword arguments:
 # Correct pipeline creation with keyword arguments
 brain_data_pipeline = IngestPipeline[BrainData](
     "brain_data",    # Required: Pipeline name
-    ingest=True,     # Required: Enable ingestion
+    ingest_api=True,     # Required: Enable ingestion
     stream=True,     # Required: Enable streaming
     table=True       # Required: Enable table storage
 )
@@ -141,7 +141,7 @@ When creating an ingest pipeline, you must ensure that:
 
 1. Configuration is provided as keyword arguments
 2. Required flags are set:
-   - `ingest=True` to enable ingestion
+   - `ingest_api=True` to enable ingestion
    - `stream=True` to enable streaming
    - `table=True` to enable table storage
 3. The pipeline name is provided as the first argument
@@ -150,7 +150,7 @@ When creating an ingest pipeline, you must ensure that:
 # Correct - Using keyword arguments
 pipeline = IngestPipeline[MyModel](
     "my_pipeline",
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 )

--- a/apps/framework-docs/llm-docs/python/pipelines.md
+++ b/apps/framework-docs/llm-docs/python/pipelines.md
@@ -113,8 +113,8 @@ When you create an `IngestPipeline` instance:
    - Creates a `Stream` with the specified configuration
    - Automatically connects to the table if one exists
    - If `stream` is `True`, uses default configuration
-3. If `ingest` is configured:
+3. If `ingest_api` is configured:
    - Creates an `IngestApi` with the specified configuration
    - Automatically connects to the stream
-   - If `ingest` is `True`, uses default configuration
+   - If `ingest_api` is `True`, uses default configuration
 

--- a/apps/framework-docs/llm-docs/python/schema-definition.md
+++ b/apps/framework-docs/llm-docs/python/schema-definition.md
@@ -25,7 +25,7 @@ When creating Python data models, you must follow these requirements exactly:
    - Use proper configuration objects, not dictionaries
    - Use IngestPipelineConfig for pipeline configuration
    - Use OlapConfig for table customization
-   - Set required flags (stream=True, ingest=True)
+   - Set required flags (stream=True, ingest_api=True)
    - Do not add undocumented fields to configurations
 
 Example of correct Python schema:
@@ -51,7 +51,7 @@ config = IngestPipelineConfig(
         engine=ClickHouseEngines.ReplacingMergeTree,
     ),
     stream=True,
-    ingest=True
+    ingest_api=True
 )
 
 pipeline = IngestPipeline[BrainData](
@@ -193,7 +193,7 @@ config = IngestPipelineConfig(
         engine=ClickHouseEngines.ReplacingMergeTree,
     ),
     stream=True,
-    ingest=True,
+    ingest_api=True,
     metadata={"description": "Brain data pipeline"}
 )
 
@@ -217,7 +217,7 @@ brain_data_pipeline = IngestPipeline[BrainData](
 
 1. **Pipeline Configuration**
    - Use `IngestPipelineConfig` object, not dictionaries
-   - Required flags: `ingest=True`, `stream=True`
+   - Required flags: `ingest_api=True`, `stream=True`
    - Table configuration must be either:
      - `True` for default settings
      - `OlapConfig` object for custom settings
@@ -233,7 +233,7 @@ brain_data_pipeline = IngestPipeline[BrainData](
            engine=ClickHouseEngines.ReplacingMergeTree,
        ),
        stream=True,
-       ingest=True
+       ingest_api=True
    )
    
    pipeline = IngestPipeline[MyModel](
@@ -258,7 +258,7 @@ brain_data_pipeline = IngestPipeline[BrainData](
            engine=ClickHouseEngines.ReplacingMergeTree,
        ),
        stream=True,
-       ingest=True,
+       ingest_api=True,
        metadata={"description": "My pipeline"}  # Invalid field
    )
    ```

--- a/apps/framework-docs/llm-docs/typescript/pipelines.md
+++ b/apps/framework-docs/llm-docs/typescript/pipelines.md
@@ -19,7 +19,7 @@ interface ExampleSchema {
 export const ExamplePipeline = new IngestPipeline<ExampleSchema>("ExamplePipeline", {
   table: true,      // Creates a basic table
   stream: true,     // Creates a basic stream
-  ingest: true      // Creates a basic ingest API
+  ingestApi: true      // Creates a basic ingest API
 });
 ```
 
@@ -31,7 +31,7 @@ The `IngestPipeline` class accepts the following configuration options:
 type DataModelConfigV2<T> = {
   table: boolean | OlapConfig<T>;        // Table configuration
   stream: boolean | Omit<StreamConfig, "destination">;  // Stream configuration
-  ingest: boolean | Omit<IngestConfig, "destination">;  // Ingest configuration
+  ingestApi: boolean | Omit<IngestConfig, "destination">;  // Ingest configuration
 };
 ```
 
@@ -100,7 +100,7 @@ When you create an `IngestPipeline` instance:
    - Creates a `Stream` with the specified configuration
    - Automatically connects to the table if one exists
    - If `stream` is `true`, uses default configuration
-3. If `ingest` is configured:
+3. If `ingestApi` is configured:
    - Creates an `IngestApi` with the specified configuration
    - Automatically connects to the stream
-   - If `ingest` is `true`, uses default configuration
+   - If `ingestApi` is `true`, uses default configuration

--- a/apps/framework-docs/src/pages/moose/apis/ingest-api.mdx
+++ b/apps/framework-docs/src/pages/moose/apis/ingest-api.mdx
@@ -193,7 +193,7 @@ interface ExampleModel {
 }
 
 const examplePipeline = new IngestPipeline<ExampleModel>("example-name", {
-  ingest: true, // Creates a REST API endpoint
+  ingestApi: true, // Creates a REST API endpoint
   stream: true, // Connects to a stream
   table: true
 });
@@ -213,7 +213,7 @@ class ExampleSchema(BaseModel):
 example_pipeline = IngestPipeline[ExampleSchema](
     name="example-name",
     config=IngestPipelineConfig(
-        ingest=True,
+        ingest_api=True,
         stream=True,
         table=True
     )
@@ -281,7 +281,7 @@ Configuration options for both high-level and low-level ingestion APIs are provi
 interface IngestPipelineConfig<T> {
   table?: boolean | OlapConfig<T>;
   stream?: boolean | Omit<StreamConfig<T>, "destination">;
-  ingest?: boolean | Omit<IngestConfig<T>, "destination">;
+  ingestApi?: boolean | Omit<IngestConfig<T>, "destination">;
   deadLetterQueue?: boolean | Omit<StreamConfig<T>, "destination">;
   version?: string;
   metadata?: {
@@ -296,7 +296,7 @@ interface IngestPipelineConfig<T> {
 class IngestPipelineConfig(BaseModel):
     table: bool | OlapConfig = True
     stream: bool | StreamConfig = True
-    ingest: bool | IngestConfig = True
+    ingest_api: bool | IngestConfig = True
     dead_letter_queue: bool | StreamConfig = True
     version: Optional[str] = None
     metadata: Optional[dict] = None

--- a/apps/framework-docs/src/pages/moose/data-modeling.mdx
+++ b/apps/framework-docs/src/pages/moose/data-modeling.mdx
@@ -125,7 +125,7 @@ interface MyDataModel {
 
 // This single interface can be reused across multiple systems:
 const pipeline = new IngestPipeline<MyDataModel>("MyDataPipeline", {
-  ingest: true,    // POST API endpoint
+  ingestApi: true,    // POST API endpoint
   stream: true,    // Kafka topic
   table: {         // ClickHouse table
     orderByFields: ["primaryKey", "someDate"]
@@ -146,7 +146,7 @@ class MyFirstDataModel(BaseModel):
 
 # This single model can be reused across multiple systems:
 my_first_pipeline = IngestPipeline[MyFirstDataModel]("my_first_pipeline", IngestPipelineConfig(
-    ingest=True,  # POST API endpoint
+    ingest_api=True,  # POST API endpoint
     stream=True,  # Kafka topic
     table=True    # ClickHouse table
 ))
@@ -275,7 +275,7 @@ export interface SimpleShared {
 
 // This SAME model creates all infrastructure
 const pipeline = new IngestPipeline<SimpleShared>("simple_shared", {
-  ingest: true,  // Creates: POST /ingest/simple_shared
+  ingestApi: true,  // Creates: POST /ingest/simple_shared
   stream: true,  // Creates: Kafka topic
   table: true    // Creates: ClickHouse table
 });
@@ -300,7 +300,7 @@ class SimpleShared(BaseModel):
 
 # This SAME model creates all infrastructure
 pipeline = IngestPipeline[SimpleShared]("simple_shared", IngestPipelineConfig(
-    ingest=True,  # Creates: POST /ingest/simple_shared
+    ingest_api=True,  # Creates: POST /ingest/simple_shared
     stream=True,  # Creates: Kafka topic
     table=True    # Creates: ClickHouse table
 ))
@@ -344,7 +344,7 @@ export interface CompositeShared {
 
 // Using in IngestPipeline - all types preserved
 const pipeline = new IngestPipeline<CompositeShared>("composite_shared", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true
 });
@@ -392,7 +392,7 @@ class CompositeShared(BaseModel):
 
 # Using in IngestPipeline - all types preserved
 pipeline = IngestPipeline[CompositeShared]("composite_shared", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
@@ -449,7 +449,7 @@ const table = new OlapTable<ClickHouseOptimized>("optimized_table", {
 
 // SCENARIO 2: IngestPipeline - optimizations ONLY in ClickHouse
 const pipeline = new IngestPipeline<ClickHouseOptimized>("optimized_pipeline", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true
 });
@@ -500,7 +500,7 @@ table = OlapTable[ClickHouseOptimized]("optimized_table", {
 
 # SCENARIO 2: IngestPipeline - optimizations ONLY in ClickHouse
 pipeline = IngestPipeline[ClickHouseOptimized]("optimized_pipeline", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))

--- a/apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx
+++ b/apps/framework-docs/src/pages/moose/migrate/lifecycle.mdx
@@ -123,7 +123,7 @@ const productAnalytics = new IngestPipeline<ProductEvent>("product_analytics", {
   stream: {
     parallelism: 4,
   },
-  ingest: true,
+  ingestApi: true,
   // automatically applied to the table and stream
   lifeCycle: LifeCycle.DELETION_PROTECTED
 });
@@ -150,7 +150,7 @@ product_analytics = IngestPipeline[ProductEvent]("product_analytics", IngestPipe
     stream=StreamConfig(
         parallelism=4,
     ),
-    ingest=True,
+    ingest_api=True,
   # automatically applied to the table and stream
   life_cycle=LifeCycle.DELETION_PROTECTED
 ))

--- a/apps/framework-docs/src/pages/moose/olap/insert-data.mdx
+++ b/apps/framework-docs/src/pages/moose/olap/insert-data.mdx
@@ -167,7 +167,7 @@ Alternatively, use `IngestPipeline` instead of standalone `IngestApi`, `Stream` 
 import { IngestPipeline } from "@514labs/moose-lib";
 
 const eventsPipeline = new IngestPipeline<Event>("user_events", {
-   ingest: true,
+   ingestApi: true,
    stream: true,
    table: {
     orderByFields: ["id", "timestamp"],
@@ -179,10 +179,10 @@ const eventsPipeline = new IngestPipeline<Event>("user_events", {
 
 <Python>
 ```py filename="IngestPipeline.py" copy
-from moose_lib import IngestPipeline, IngestConfig
+from moose_lib import IngestPipeline, IngestPipelineConfig
 
-ingest_pipeline = IngestPipeline[Event]("user_events", IngestConfig(
-    ingest=True,
+ingest_pipeline = IngestPipeline[Event]("user_events", IngestPipelineConfig(
+    ingest_api=True,
     stream=True,
     table=True,
 ))

--- a/apps/framework-docs/src/pages/moose/reference/py-moose-lib.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/py-moose-lib.mdx
@@ -113,7 +113,7 @@ Configuration for creating a complete data pipeline.
 class IngestPipelineConfig(BaseModel):
     table: bool | OlapConfig = True
     stream: bool | StreamConfig = True
-    ingest: bool | IngestConfig = True
+    ingest_api: bool | IngestConfig = True
 ```
 
 ## Infrastructure Components
@@ -189,14 +189,14 @@ from moose_lib.blocks import ReplacingMergeTreeEngine
 
 # Basic usage
 pipeline = IngestPipeline[UserEvent]("user_pipeline", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=True,
     table=True
 ))
 
 # With advanced configuration
 pipeline = IngestPipeline[UserEvent]("user_pipeline", IngestPipelineConfig(
-    ingest=True,
+    ingest_api=True,
     stream=StreamConfig(parallelism=3),
     table=OlapConfig(
         order_by_fields=["id", "timestamp"],

--- a/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
+++ b/apps/framework-docs/src/pages/moose/reference/ts-moose-lib.mdx
@@ -110,14 +110,14 @@ Combines ingest API, stream, and table creation in a single component.
 ```ts
 // Basic usage
 export const pipeline = new IngestPipeline<UserEvent>("user_pipeline", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true
 });
 
 // With advanced configuration
 export const advancedPipeline = new IngestPipeline<UserEvent>("advanced_pipeline", {
-  ingest: true,
+  ingestApi: true,
   stream: { parallelism: 3 },
   table: { 
     orderByFields: ["id", "timestamp"]

--- a/apps/framework-docs/src/pages/moose/streaming/dead-letter-queues.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/dead-letter-queues.mdx
@@ -534,7 +534,7 @@ interface ExampleSchema {
 }
 
 const pipeline = new IngestPipeline<ExampleSchema>("example", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: true,
   deadLetterQueue: true, // Route failed ingestions to DLQ
@@ -558,7 +558,7 @@ example_dlq = DeadLetterQueue[ExampleSchema](name="exampleDLQ")
 pipeline = IngestPipeline[ExampleSchema](
     name="example",
     config=IngestPipelineConfig(
-        ingest=True,
+        ingest_api=True,
         stream=True,
         table=True,
         dead_letter_queue=True  # Route failed ingestions to DLQ

--- a/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
@@ -20,9 +20,9 @@ The most common way to publish data is through Moose's built-in ingestion APIs. 
 
 <TypeScript>
 ```typescript filename="PublishViaAPI.ts"
-// When you create an IngestPipeline with ingest: true, Moose automatically creates an API endpoint
+// When you create an IngestPipeline with ingestApi: true, Moose automatically creates an API endpoint
 const rawData = new IngestPipeline<RawData>("raw_data", {
-  ingest: true, // Creates POST /ingest/raw_data endpoint
+  ingestApi: true, // Creates POST /ingest/raw_data endpoint
   stream: true,
   table: true
 });
@@ -44,13 +44,14 @@ const response = await fetch('/ingest/raw_data', {
 <Python>
 ```py filename="PublishViaAPI.py" copy
 import requests
+from moose_lib import IngestPipeline, IngestPipelineConfig
 
-# When you create an IngestPipeline with ingest: True, Moose automatically creates an API endpoint
-raw_data = IngestPipeline[RawData]("raw_data", {
-  ingest: True, # Creates POST /ingest/raw_data endpoint
-  stream: True,
-  table: True
-})
+# When you create an IngestPipeline with ingest_api: True, Moose automatically creates an API endpoint
+raw_data = IngestPipeline[RawData]("raw_data", IngestPipelineConfig(
+  ingest_api=True, # Creates POST /ingest/raw_data endpoint
+  stream=True,
+  table=True
+))
 
 # You can then publish data via HTTP POST requests
 response = requests.post('/ingest/raw_data', json={
@@ -64,85 +65,9 @@ response = requests.post('/ingest/raw_data', json={
 See the [OpenAPI documentation](/stack/open-api) to learn more about how to generate type-safe client SDKs in your language of choice for all of your Moose APIs.
 </Callout>
 
-### Direct Stream Publishing
+### Direct Stream Publishing (Coming Soon)
 
-You can publish directly to a stream from your Moose code using the stream's `send` method.
-This is useful when emitting events from workflows or other backend logic.
-`send` accepts a single record or an array of records.
-
-<Tabs items={["TypeScript", "Python"]}>
-<Tabs.Tab>
-<TypeScript>
-```ts filename="DirectPublish.ts" copy
-import { Stream, Key } from "@514labs/moose-lib";
-
-interface UserEvent {
-  id: Key<string>;
-  userId: string;
-  timestamp: Date;
-  eventType: string;
-}
-
-// Create a stream (optionally configure destination to sync to a table)
-const events = new Stream<UserEvent>("user-events");
-
-// Publish a single record
-await events.send({
-  id: "evt_1",
-  userId: "user_123",
-  timestamp: new Date(),
-  eventType: "click",
-});
-
-// Publish multiple records
-await events.send([
-  { id: "evt_2", userId: "user_456", timestamp: new Date(), eventType: "view" },
-  { id: "evt_3", userId: "user_789", timestamp: new Date(), eventType: "signup" },
-]);
-```
-</TypeScript>
-</Tabs.Tab>
-
-<Tabs.Tab>
-<Python>
-```py filename="DirectPublish.py" copy
-from moose_lib import Stream, StreamConfig, Key
-from pydantic import BaseModel
-from datetime import datetime
-
-class UserEvent(BaseModel):
-    id: Key[str]
-    user_id: str
-    timestamp: datetime
-    event_type: str
-
-# Create a stream (optionally pass StreamConfig with destination/table settings)
-events = Stream[UserEvent]("user_events", StreamConfig())
-
-# Publish a single record
-events.send(UserEvent(
-    id="evt_1",
-    user_id="user_123",
-    timestamp=datetime.now(),
-    event_type="click"
-))
-
-# Publish multiple records
-events.send([
-    UserEvent(id="evt_2", user_id="user_456", timestamp=datetime.now(), event_type="view"),
-    UserEvent(id="evt_3", user_id="user_789", timestamp=datetime.now(), event_type="signup"),
-])
-```
-</Python>
-</Tabs.Tab>
-</Tabs>
-
-<Callout type="info" title="Topic naming and versions">
-Moose builds the Kafka topic name from your stream name,
-optional namespace, and optional version (dots become underscores).
-For example, a stream named `events` with version `1.2.0` becomes `events_1_2_0`
-(or `my_ns.events_1_2_0` when the namespace is `"my_ns"`).
-</Callout>
+Soon, you will be able to publish directly to streams using the stream's publish method. This is an efficient way to publish data to streams from within other parts of your Moose backend--in particular, from your workflows.
 
 ### Using the Kafka/Redpanda Client from External Applications
 You can also publish to streams from external applications using Kafka/Redpanda clients:

--- a/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/from-your-code.mdx
@@ -65,9 +65,85 @@ response = requests.post('/ingest/raw_data', json={
 See the [OpenAPI documentation](/stack/open-api) to learn more about how to generate type-safe client SDKs in your language of choice for all of your Moose APIs.
 </Callout>
 
-### Direct Stream Publishing (Coming Soon)
+### Direct Stream Publishing
 
-Soon, you will be able to publish directly to streams using the stream's publish method. This is an efficient way to publish data to streams from within other parts of your Moose backend--in particular, from your workflows.
+You can publish directly to a stream from your Moose code using the stream's `send` method.
+This is useful when emitting events from workflows or other backend logic.
+`send` accepts a single record or an array of records.
+
+<Tabs items={["TypeScript", "Python"]}>
+<Tabs.Tab>
+<TypeScript>
+```ts filename="DirectPublish.ts" copy
+import { Stream, Key } from "@514labs/moose-lib";
+
+interface UserEvent {
+  id: Key<string>;
+  userId: string;
+  timestamp: Date;
+  eventType: string;
+}
+
+// Create a stream (optionally configure destination to sync to a table)
+const events = new Stream<UserEvent>("user-events");
+
+// Publish a single record
+await events.send({
+  id: "evt_1",
+  userId: "user_123",
+  timestamp: new Date(),
+  eventType: "click",
+});
+
+// Publish multiple records
+await events.send([
+  { id: "evt_2", userId: "user_456", timestamp: new Date(), eventType: "view" },
+  { id: "evt_3", userId: "user_789", timestamp: new Date(), eventType: "signup" },
+]);
+```
+</TypeScript>
+</Tabs.Tab>
+
+<Tabs.Tab>
+<Python>
+```py filename="DirectPublish.py" copy
+from moose_lib import Stream, StreamConfig, Key
+from pydantic import BaseModel
+from datetime import datetime
+
+class UserEvent(BaseModel):
+    id: Key[str]
+    user_id: str
+    timestamp: datetime
+    event_type: str
+
+# Create a stream (optionally pass StreamConfig with destination/table settings)
+events = Stream[UserEvent]("user_events", StreamConfig())
+
+# Publish a single record
+events.send(UserEvent(
+    id="evt_1",
+    user_id="user_123",
+    timestamp=datetime.now(),
+    event_type="click"
+))
+
+# Publish multiple records
+events.send([
+    UserEvent(id="evt_2", user_id="user_456", timestamp=datetime.now(), event_type="view"),
+    UserEvent(id="evt_3", user_id="user_789", timestamp=datetime.now(), event_type="signup"),
+])
+```
+</Python>
+</Tabs.Tab>
+</Tabs>
+
+<Callout type="info" title="Topic naming and versions">
+Moose builds the Kafka topic name from your stream name,
+optional namespace, and optional version (dots become underscores).
+For example, a stream named `events` with version `1.2.0` becomes `events_1_2_0`
+(or `my_ns.events_1_2_0` when the namespace is `"my_ns"`).
+</Callout>
 
 ### Using the Kafka/Redpanda Client from External Applications
 You can also publish to streams from external applications using Kafka/Redpanda clients:

--- a/apps/framework-docs/src/pages/moose/streaming/sync-to-table.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/sync-to-table.mdx
@@ -94,7 +94,7 @@ interface Event {
 
 // Creates stream, table, API, and automatic sync
 const eventsPipeline = new IngestPipeline<Event>("events", {
-  ingest: true,   // Creates HTTP endpoint at POST /ingest/events
+  ingestApi: true,   // Creates HTTP endpoint at POST /ingest/events
   stream: true,   // Creates buffering stream
   table: true     // Creates destination table + auto-sync process
 });
@@ -115,7 +115,7 @@ class Event(BaseModel):
 
 # Creates stream, table, API, and automatic sync
 events_pipeline = IngestPipeline[Event]("events", IngestPipelineConfig(
-    ingest=True,   
+    ingest_api=True,   
     stream=True,   # Creates stream  
     table=True     # Creates destination table + auto-sync process
 ))

--- a/apps/framework-docs/src/pages/moose/streaming/transform-functions.mdx
+++ b/apps/framework-docs/src/pages/moose/streaming/transform-functions.mdx
@@ -493,13 +493,13 @@ interface ProcessedEvent {
 
 // Create pipelines
 const rawEvents = new IngestPipeline<UserEvent>("raw_events", {
-  ingest: true,
+  ingestApi: true,
   stream: true,
   table: false
 });
 
 const processedEvents = new IngestPipeline<ProcessedEvent>("processed_events", {
-  ingest: false,
+  ingestApi: false,
   stream: true,
   table: true
 });
@@ -542,7 +542,7 @@ eventDLQ.addConsumer((deadLetter) => {
 
 <Python>
 ```py filename="DeadLetterQueue.py" copy
-from moose_lib import DeadLetterQueue, IngestPipeline, TransformConfig, DeadLetterModel
+from moose_lib import DeadLetterQueue, IngestPipeline, IngestPipelineConfig, TransformConfig, DeadLetterModel
 from pydantic import BaseModel
 from datetime import datetime
 
@@ -558,17 +558,17 @@ class ProcessedEvent(BaseModel):
     is_valid: bool
 
 # Create pipelines
-raw_events = IngestPipeline[UserEvent]("raw_events", {
-    "ingest": True,
-    "stream": True,
-    "table": False
-})
+raw_events = IngestPipeline[UserEvent]("raw_events", IngestPipelineConfig(
+    ingest_api=True,
+    stream=True,
+    table=False
+))
 
-processed_events = IngestPipeline[ProcessedEvent]("processed_events", {
-    "ingest": False,
-    "stream": True,
-    "table": True
-})
+processed_events = IngestPipeline[ProcessedEvent]("processed_events", IngestPipelineConfig(
+    ingest_api=False,
+    stream=True,
+    table=True
+))
 
 # Create dead letter queue for failed transformations
 event_dlq = DeadLetterQueue[UserEvent](name="EventDLQ")

--- a/apps/framework-docs/src/pages/sloan/guides/clickhouse-proj.mdx
+++ b/apps/framework-docs/src/pages/sloan/guides/clickhouse-proj.mdx
@@ -137,7 +137,7 @@ const acPipeline = new IngestPipeline<AircraftTrackingProcessed>(
     {
       table: true,
       stream: true,
-      ingest: false,
+      ingestApi: false,
       metadata: {
           description: "Pipeline for ingesting raw aircraft data" } // new description field!
       }

--- a/apps/framework-docs/src/pages/sloan/guides/from-template.mdx
+++ b/apps/framework-docs/src/pages/sloan/guides/from-template.mdx
@@ -82,7 +82,7 @@ const acPipeline = new IngestPipeline<AircraftTrackingProcessed>(
     {
       table: true,
       stream: true,
-      ingest: false,
+      ingestApi: false,
       metadata: {
           description: "Pipeline for ingesting raw aircraft data" } // new description field!
       }

--- a/apps/framework-docs/src/pages/sloan/reference/tool-reference.mdx
+++ b/apps/framework-docs/src/pages/sloan/reference/tool-reference.mdx
@@ -457,7 +457,7 @@ export interface AircraftTrackingData {
 // Define ingest pipelines
 export const AircraftTrackingDataPipeline = new IngestPipeline<AircraftTrackingData>(
   "AircraftTrackingData", 
-  { table: false, stream: true, ingest: true }
+  { table: false, stream: true, ingestApi: true }
 );
 ```
 

--- a/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/ingest_pipeline.py
@@ -54,11 +54,12 @@ class IngestPipelineConfig(BaseModel):
                 DeprecationWarning,
                 stacklevel=3
             )
+            # Make a copy first to avoid mutating the original dictionary
+            data = data.copy()
             # If ingest_api is not explicitly set, use the ingest value
             if 'ingest_api' not in data:
                 data['ingest_api'] = data['ingest']
             # Remove the legacy parameter
-            data = data.copy()
             del data['ingest']
         return data
 


### PR DESCRIPTION
## Summary
- Comprehensive documentation updates for IngestPipeline parameter names
- Fix Python validator mutation bug
- Ensure consistency with the already-merged functionality from #2814

## Changes Made

### 📚 Documentation Updates
- **TypeScript examples**: Updated to use `ingestApi` (camelCase) consistently 
- **Python examples**: Updated to use `ingest_api` (snake_case) consistently
- **Configuration imports**: Fixed Python examples to use `IngestPipelineConfig` instead of `IngestConfig`
- **Reference docs**: Updated both TypeScript and Python API references
- **LLM docs**: Updated AI-optimized documentation for consistency
- **Guide examples**: Updated all guides and tutorials

### 🐛 Bug Fix  
- **Validator mutation fix**: Fixed Python `@model_validator` that was mutating caller's original dictionary
- **Root cause**: Validator was modifying input before making a copy, causing issues with dictionary reuse
- **Solution**: Make copy first before any modifications

### 📊 Impact
- **18 files updated** with consistent parameter naming
- **Documentation now matches implementation** from merged PR #2814
- **Bug prevents issues** when reusing configuration dictionaries

## Test Plan
- [x] All documentation examples use correct parameter names
- [x] Python validator no longer mutates input dictionaries  
- [x] Pre-commit hooks pass (prettier, linting)
- [x] Consistent with existing functionality

## Context
This PR complements the already-merged #2814 which implemented the core IngestPipeline parameter rename functionality. While the implementation was merged, the documentation was not comprehensively updated and a validator bug was discovered during review.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `ingest` to `ingestApi`/`ingest_api` across docs and fixes Python validator to copy config dict before mapping legacy `ingest` to `ingest_api`.
> 
> - **Documentation**
>   - Rename `ingest` to `ingestApi` (TypeScript) and `ingest_api` (Python) across guides, LLM docs, and reference pages.
>   - Update examples to use `IngestPipelineConfig` in Python; adjust “How It Works” bullets to reference `ingestApi/ingest_api`.
>   - Fix TypeScript/Python config interfaces to reflect new field names.
> - **Python Library** (`moose_lib/dmv2/ingest_pipeline.py`)
>   - `@model_validator` now copies input dict before modifying, mapping legacy `ingest` -> `ingest_api` and avoiding caller mutation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9690664bd0a6eacb5036a5ae7388fee4176ccfae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->