### PR TITLE
make it clear that clippy warnings should be fixed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ You can find the logs for moose if you need to troublehoot into `~/.moose/*-cli.
 ### Rust Components
 - **Build Rust**: `cargo build`
 - **Run Rust tests**: `cargo test`
-- **Lint Rust code**: `cargo clippy`
+- **Lint Rust code**: `cargo clippy -D warnings` (no warnings allowed)
 - **Format Rust code**: `rustfmt --edition 2021 <file.rs>`
 
 ### Testing
@@ -67,7 +67,7 @@ This is a multi-language monorepo using:
 
 ### Pre-commit Requirements
 - **TypeScript/JavaScript**: Must pass linting and code formating checks (`npx lint-staged`)
-- **Rust**: Must pass `cargo clippy` 
+- **Rust**: Must pass `cargo clippy -D warnings` (no warnings permitted)
 - **All components**: Tests must pass before PR submission
 
 ### Error Handling (Rust)
@@ -80,7 +80,7 @@ This is a multi-language monorepo using:
 - **Constants**: Use `const` in Rust, place in `constants.rs` at appropriate module level
 - **Newtypes**: Use tuple structs with validation constructors
 - **Documentation**: All public APIs must be documented
-- **Linting**: Always run `cargo clippy` for Rust code
+- **Linting**: Always run `cargo clippy -D warnings` for Rust code
 - Follow existing patterns and conventions in each language
 
 ### Templates

--- a/apps/framework-cli/AGENTS.md
+++ b/apps/framework-cli/AGENTS.md
@@ -6,11 +6,12 @@ This directory contains the main Rust CLI application for Moose. Follow these st
 ## Development Commands
 - **Build**: `cargo build`
 - **Test**: `cargo test`
-- **Lint**: `cargo clippy` (required before commits)
+- **Lint**: `cargo clippy -D warnings` (required; zero warnings allowed)
 - **Format**: `rustfmt --edition 2021 <file.rs>`
 
 ## Code Quality Requirements
-- **Always run `cargo clippy`** before commits - trust Clippy's guidance
+- **Always run `cargo clippy -D warnings`** before commits; fix all warnings
+- No Clippy warnings may remain (treat warnings as errors)
 - Use `rustfmt --edition 2021` for consistent formatting
 - Write meaningful names: functions, variables, types
 - Keep functions focused and modular


### PR DESCRIPTION
I got "Status: Clippy passes (only warnings)." in an agent chat session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs to require running `cargo clippy -D warnings`, treating all Clippy warnings as errors.
> 
> - **Docs**:
>   - Update `AGENTS.md`:
>     - Replace `cargo clippy` with `cargo clippy -D warnings` in Rust linting, pre-commit, and linting guidelines (no warnings permitted).
>   - Update `apps/framework-cli/AGENTS.md`:
>     - Change lint command to `cargo clippy -D warnings` and require zero warnings before commits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f9e5d8498349cce5d5bbb2f084a6c49a2b5b5c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->