### PR TITLE
Schema registry JSON schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
+ "serde",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -126,6 +128,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "apache-avro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce74162d8bc5bc22bd746e1849fb33f2c9416d2ce505d1d65ba49f170a207c90"
+dependencies = [
+ "bigdecimal",
+ "bon",
+ "digest",
+ "log",
+ "miniz_oxide",
+ "num-bigint",
+ "quad-rand",
+ "rand 0.9.2",
+ "regex-lite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -341,6 +367,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +418,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2529c31017402be841eb45892278a6c21a000c0a17643af326c73a73f83f0fb"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82020dadcb845a345591863adb65d74fa8dc5c18a0b6d408470e13b7adc7005"
+dependencies = [
+ "darling 0.21.3",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
+
+[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +482,37 @@ name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+
+[[package]]
+name = "camino"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cassowary"
@@ -609,8 +733,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
  "crossterm 0.28.1",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width 0.2.0",
 ]
 
@@ -849,8 +973,18 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -868,14 +1002,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.10",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -916,7 +1088,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -1025,6 +1197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1273,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1352,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1396,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1400,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
 dependencies = [
  "cfg-if",
- "dashmap",
+ "dashmap 6.1.0",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -1521,6 +1743,15 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1982,6 +2213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
+
+[[package]]
 name = "inventory"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2086,6 +2323,33 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+dependencies = [
+ "ahash 0.8.11",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest 0.12.12",
+ "serde",
+ "serde_json",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -2448,6 +2712,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,9 +2744,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -2527,7 +2816,7 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-util",
  "log",
- "rand 0.9.0",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2560,6 +2849,7 @@ dependencies = [
  "flate2",
  "futures",
  "git2",
+ "globset",
  "handlebars",
  "hex",
  "home",
@@ -2600,6 +2890,7 @@ dependencies = [
  "reqwest 0.12.12",
  "rustpython-ast",
  "rustpython-parser",
+ "schema-registry-client",
  "semver",
  "serde",
  "serde_json",
@@ -2710,12 +3001,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2731,6 +3052,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2857,7 +3200,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -2932,7 +3275,7 @@ dependencies = [
  "opentelemetry_sdk 0.29.0",
  "prost",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -3014,12 +3357,21 @@ dependencies = [
  "glob",
  "opentelemetry 0.29.0",
  "percent-encoding",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3031,6 +3383,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -3122,7 +3480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
@@ -3302,7 +3660,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3415,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3425,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.13.0",
@@ -3445,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -3457,10 +3815,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.13.4"
+name = "prost-reflect"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+dependencies = [
+ "base64 0.22.1",
+ "prost",
+ "prost-reflect-derive",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8db7191445b1dbee19df4f6b6294e5123aef52620b344a630bb845d302622a"
+dependencies = [
+ "prost-build",
+ "prost-reflect",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab076798900edeaf1499ed1c30097db86e6697c5d02660a63d72fe4ebdcfefd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
@@ -3578,6 +3971,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.7.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
+
+[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,13 +4030,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3681,8 +4090,8 @@ dependencies = [
  "lru",
  "paste",
  "stability",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.1.14",
@@ -3784,6 +4193,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "referencing"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+dependencies = [
+ "ahash 0.8.11",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,6 +4248,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30"
 
 [[package]]
 name = "regex-syntax"
@@ -3876,6 +4325,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -4177,6 +4627,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "schema-registry-client"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8785a86cb0e6ab4f51be9d87a5a703638f066827fb7c367ae43ca60cc57b5c15"
+dependencies = [
+ "apache-avro",
+ "async-recursion",
+ "async-trait",
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "dashmap 6.1.0",
+ "fastrand",
+ "futures",
+ "integer-encoding",
+ "jsonschema",
+ "lazy_static",
+ "log",
+ "mini-moka",
+ "prost",
+ "prost-build",
+ "prost-reflect",
+ "prost-reflect-build",
+ "prost-types",
+ "referencing",
+ "regex",
+ "reqwest 0.12.12",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tink-core",
+ "tokio",
+ "trait-variant",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4241,21 +4729,54 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4334,6 +4855,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4421,6 +4953,21 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
 
 [[package]]
 name = "slab"
@@ -4532,8 +5079,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -4545,6 +5098,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -4658,6 +5223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tar"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4704,7 +5275,7 @@ dependencies = [
  "slotmap",
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tokio",
  "tonic",
  "tower 0.5.2",
@@ -4723,7 +5294,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_builder",
  "derive_more 1.0.0",
  "enum-iterator",
@@ -4758,7 +5329,7 @@ dependencies = [
  "temporal-client",
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4782,7 +5353,7 @@ dependencies = [
  "prost-types",
  "serde_json",
  "temporal-sdk-core-protos",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tonic",
  "tracing-core",
  "url",
@@ -4805,7 +5376,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.17",
  "tonic",
  "tonic-build",
  "uuid",
@@ -4861,11 +5432,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.10"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.10",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -4881,9 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.10"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4929,6 +5500,32 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tink-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3b5191c899ab9f17fe120fc93246768aaf5e7e0e287e237a11ee34d5ed97ba"
+dependencies = [
+ "digest",
+ "hkdf",
+ "lazy_static",
+ "rand 0.8.5",
+ "sha-1",
+ "sha2",
+ "subtle",
+ "tink-proto",
+]
+
+[[package]]
+name = "tink-proto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99453d1a061b1106de7e12dff76fa1026bb86a6daa4039bc2c21b212fb85ac98"
+dependencies = [
+ "prost",
+ "prost-build",
 ]
 
 [[package]]
@@ -5221,6 +5818,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5333,6 +5947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5438,12 +6058,25 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
 ]
 
 [[package]]
@@ -5463,6 +6096,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -5509,20 +6148,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -5534,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5547,9 +6188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5557,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5570,9 +6211,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -5589,9 +6233,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5977,16 +6621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -5994,17 +6629,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/framework-cli/Cargo.toml
+++ b/apps/framework-cli/Cargo.toml
@@ -109,6 +109,8 @@ prost-types = "0.13.0"
 tonic = { version = "0.12", features = ["transport", "prost", "codegen"] }
 tempfile = "3.15.0"
 prost-wkt-types = "0.6.0"
+globset = "0.4"
+schema-registry-client = "0.4.1"
 
 keyring = { version = "3.6", features = ["apple-native", "linux-native"] }
 

--- a/apps/framework-cli/src/cli.rs
+++ b/apps/framework-cli/src/cli.rs
@@ -1174,19 +1174,12 @@ pub async fn top_command_handler(
                 schema_registry,
             } => {
                 let project = load_project()?;
-                let path = path.as_deref().unwrap_or_else(|| match project.language {
+                let path = path.as_deref().unwrap_or(match project.language {
                     SupportedLanguages::Typescript => "app/external-topics",
                     SupportedLanguages::Python => "app/external_topics",
                 });
-                write_external_topics(
-                    &project,
-                    bootstrap,
-                    &path,
-                    include,
-                    exclude,
-                    schema_registry,
-                )
-                .await?;
+                write_external_topics(&project, bootstrap, path, include, exclude, schema_registry)
+                    .await?;
                 Ok(RoutineSuccess::success(Message::new(
                     "Kafka".to_string(),
                     "external topics written".to_string(),

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -356,7 +356,7 @@ pub enum DbCommands {
 #[command(arg_required_else_help = true)]
 pub struct KafkaArgs {
     #[command(subcommand)]
-    pub command: Option<KafkaCommands>,
+    pub command: KafkaCommands,
 }
 
 #[derive(Debug, Subcommand)]
@@ -368,15 +368,15 @@ pub enum KafkaCommands {
 
         /// Output path for schemas
         #[arg(long, value_name = "PATH")]
-        path: String,
+        path: Option<String>,
 
         /// Include pattern (glob). Defaults to '*'
         #[arg(long, default_value = "*")]
         include: String,
 
-        /// Exclude pattern (glob)
-        #[arg(long)]
-        exclude: Option<String>,
+        /// Exclude pattern (glob). Defaults to '{__consumer_offsets,_schemas}'
+        #[arg(long, default_value = "{__consumer_offsets,_schemas}")]
+        exclude: String,
 
         /// Schema Registry base URL (e.g. http://localhost:8081)
         #[arg(long, value_name = "URL")]

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -361,7 +361,9 @@ pub struct KafkaArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum KafkaCommands {
-    /// Pull schemas from Kafka (dummy implementation)
+    /// Discover topics and generate external stream declarations;
+    /// optionally fetch JSON Schemas (Avro support coming soon)
+    /// from Schema Registry to emit typed models.
     Pull {
         /// Kafka bootstrap servers, e.g. localhost:9092
         bootstrap: String,

--- a/apps/framework-cli/src/cli/commands.rs
+++ b/apps/framework-cli/src/cli/commands.rs
@@ -170,6 +170,8 @@ pub enum Commands {
         #[arg(long)]
         rows: Option<u64>,
     },
+    /// Manage Kafka-related operations
+    Kafka(KafkaArgs),
 }
 
 #[derive(Debug, Args)]
@@ -347,5 +349,37 @@ pub enum DbCommands {
         /// File storing the EXTERNALLY_MANAGED table definitions, defaults to app/external_models.py or app/externalModels.ts
         #[arg(long)]
         file_path: Option<String>,
+    },
+}
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct KafkaArgs {
+    #[command(subcommand)]
+    pub command: Option<KafkaCommands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum KafkaCommands {
+    /// Pull schemas from Kafka (dummy implementation)
+    Pull {
+        /// Kafka bootstrap servers, e.g. localhost:9092
+        bootstrap: String,
+
+        /// Output path for schemas
+        #[arg(long, value_name = "PATH")]
+        path: String,
+
+        /// Include pattern (glob). Defaults to '*'
+        #[arg(long, default_value = "*")]
+        include: String,
+
+        /// Exclude pattern (glob)
+        #[arg(long)]
+        exclude: Option<String>,
+
+        /// Schema Registry base URL (e.g. http://localhost:8081)
+        #[arg(long, value_name = "URL")]
+        schema_registry: Option<String>,
     },
 }

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -42,7 +42,7 @@ use crate::utilities::auth::{get_claims, validate_jwt};
 use crate::infrastructure::stream::kafka;
 use crate::infrastructure::stream::kafka::models::ConfiguredProducer;
 
-use crate::framework::core::infrastructure::topic::SchemaResgistryReference;
+use crate::framework::core::infrastructure::topic::SchemaRegistryReference;
 use crate::framework::typescript::bin::CliMessage;
 use crate::project::{JwtConfig, Project};
 use crate::utilities::docker::DockerClient;
@@ -137,16 +137,16 @@ async fn resolve_schema_id_for_topic(
     project: &Project,
     topic: &crate::framework::core::infrastructure::topic::Topic,
 ) -> Result<Option<i32>, schema_registry_client::rest::apis::Error> {
-    let sr = match &topic.schema_registry {
+    let sr = match &topic.schema_config {
         Some(sr) if sr.kind.eq_ignore_ascii_case("JSON") => sr,
         None => return Ok(None),
         _ => panic!("Only JSON schema allowed"),
     };
 
     let (subject, explicit_version): (&str, Option<i32>) = match &sr.reference {
-        SchemaResgistryReference::Id(id) => return Ok(Some(*id)),
-        SchemaResgistryReference::Latest { subject_name } => (subject_name, None),
-        SchemaResgistryReference::SubjectVersion { name, version } => (name, Some(*version)),
+        SchemaRegistryReference::Id { id } => return Ok(Some(*id)),
+        SchemaRegistryReference::SubjectLatest { subject_latest } => (subject_latest, None),
+        SchemaRegistryReference::SubjectVersion { subject, version } => (subject, Some(*version)),
     };
 
     let sr_url = project

--- a/apps/framework-cli/src/cli/local_webserver.rs
+++ b/apps/framework-cli/src/cli/local_webserver.rs
@@ -79,7 +79,6 @@ use crate::utilities::validate_passthrough::{DataModelArrayVisitor, DataModelVis
 use hyper_util::server::graceful::GracefulShutdown;
 use lazy_static::lazy_static;
 use log::Level::{Debug, Trace};
-use num_traits::ToPrimitive;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::env::VarError;
@@ -169,7 +168,7 @@ async fn resolve_schema_id_for_topic(
             .into_iter()
             .max()
             .unwrap(),
-        Some(v) => v.to_i32().unwrap(),
+        Some(v) => v,
     };
 
     Ok(Some(

--- a/apps/framework-cli/src/cli/routines.rs
+++ b/apps/framework-cli/src/cli/routines.rs
@@ -163,6 +163,7 @@ pub mod clean;
 pub mod code_generation;
 pub mod dev;
 pub mod docker_packager;
+pub mod kafka_pull;
 pub mod logs;
 pub mod ls;
 pub mod metrics_console;

--- a/apps/framework-cli/src/cli/routines/kafka_pull.rs
+++ b/apps/framework-cli/src/cli/routines/kafka_pull.rs
@@ -1,0 +1,355 @@
+use crate::cli::display::{Message, MessageType};
+use crate::cli::routines::RoutineFailure;
+use crate::framework::languages::SupportedLanguages;
+use crate::infrastructure::stream::kafka::client::fetch_topics;
+use crate::project::Project;
+use convert_case::{Case, Casing};
+use globset::Glob;
+use log::{info, warn};
+use schema_registry_client::rest::apis::Error as SchemaRegistryError;
+use schema_registry_client::rest::schema_registry_client::{
+    Client as SrClientTrait, SchemaRegistryClient,
+};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+fn build_matchers(
+    include: &str,
+    exclude: &Option<String>,
+) -> Result<(globset::GlobMatcher, Option<globset::GlobMatcher>), RoutineFailure> {
+    let inc = Glob::new(include).map_err(|e| {
+        RoutineFailure::new(
+            Message::new("Kafka".to_string(), format!("invalid include glob: {e}")),
+            e,
+        )
+    })?;
+    let inc_matcher = inc.compile_matcher();
+
+    let exc_matcher = match exclude {
+        Some(pat) => match Glob::new(pat) {
+            Ok(g) => Some(g.compile_matcher()),
+            Err(e) => {
+                warn!("Ignoring invalid exclude glob '{}': {:?}", pat, e);
+                None
+            }
+        },
+        None => None,
+    };
+    Ok((inc_matcher, exc_matcher))
+}
+
+pub async fn write_external_topics(
+    project: &Project,
+    bootstrap: &str,
+    path: &str,
+    include: &str,
+    exclude: Option<String>,
+    schema_registry: &Option<String>,
+) -> Result<(), RoutineFailure> {
+    info!(
+        "Fetching topics from {} with include='{}' exclude='{:?}'",
+        bootstrap, include, exclude
+    );
+
+    let mut kafka_cfg = project.redpanda_config.clone();
+    kafka_cfg.broker = bootstrap.to_string();
+
+    let (inc, exc) = build_matchers(include, &exclude)?;
+
+    let topics = fetch_topics(&kafka_cfg).await.map_err(|e| {
+        RoutineFailure::new(
+            Message::new("Kafka".to_string(), "failed to fetch topics".to_string()),
+            e,
+        )
+    })?;
+
+    let mut names: Vec<String> = topics
+        .into_iter()
+        .map(|t| t.name)
+        .filter(|n| inc.is_match(n) && exc.as_ref().map(|m| !m.is_match(n)).unwrap_or(true))
+        .collect();
+    names.sort();
+
+    fs::create_dir_all(path).map_err(|e| {
+        RoutineFailure::new(
+            Message::new("Kafka".to_string(), format!("creating directory {path}")),
+            e,
+        )
+    })?;
+
+    // Build type maps by fetching schemas first (if configured)
+    let mut ts_type_map: std::collections::HashMap<String, (String, String)> = Default::default();
+    let mut py_type_map: std::collections::HashMap<String, (String, String)> = Default::default();
+    if let Some(sr_url) = schema_registry {
+        let config = schema_registry_client::rest::client_config::ClientConfig {
+            base_urls: vec![sr_url.to_string()],
+            ..Default::default()
+        };
+        let sr_client = SchemaRegistryClient::new(config);
+        for topic in &names {
+            let subject = format!("{}-value", topic);
+            match fetch_latest_json_schema(&sr_client, &subject).await {
+                Ok(Some(schema_json)) => match project.language {
+                    SupportedLanguages::Typescript => {
+                        let type_name = sanitize_ts_ident(topic);
+                        let file_stem = type_name.clone();
+                        let out = Path::new(path).join(format!("{file_stem}.ts"));
+                        if let Err(e) =
+                            generate_typescript_from_schema_named(&schema_json, &out, &type_name)
+                        {
+                            warn!("Failed to generate TS for {}: {:?}", subject, e);
+                        } else {
+                            ts_type_map.insert(topic.clone(), (type_name, file_stem));
+                        }
+                    }
+                    SupportedLanguages::Python => {
+                        // Ensure package for relative imports
+                        let init_py = Path::new(path).join("__init__.py");
+                        if !init_py.exists() {
+                            let _ = fs::write(&init_py, b"");
+                        }
+                        let class_name = sanitize_ts_ident(topic); // PascalCase class name
+                        let module_stem = sanitize_py_ident(topic);
+                        let out = Path::new(path).join(format!("{module_stem}.py"));
+                        if let Err(e) =
+                            generate_python_from_schema_named(&schema_json, &out, &class_name)
+                        {
+                            warn!("Failed to generate Python for {}: {:?}", subject, e);
+                        } else {
+                            py_type_map.insert(topic.clone(), (class_name, module_stem));
+                        }
+                    }
+                },
+                Ok(None) => {
+                    println!("No such schema found for {}", topic);
+                    // No JSON schema for this subject
+                }
+                Err(e) => {
+                    println!("Failed to fetch schema for {}: {:?}", subject, e);
+                    warn!("Failed to fetch schema for {}: {:?}", subject, e);
+                }
+            }
+        }
+    }
+
+    // Now write stream declarations with imports referencing generated types where available
+    match project.language {
+        SupportedLanguages::Typescript => {
+            let file_path = Path::new(path).join("externalTopics.ts");
+            let contents = render_typescript_streams(&names, &ts_type_map);
+            fs::write(&file_path, contents.as_bytes()).map_err(|e| {
+                RoutineFailure::new(
+                    Message::new(
+                        "Kafka".to_string(),
+                        format!("writing {}", file_path.display()),
+                    ),
+                    e,
+                )
+            })?;
+            crate::cli::display::show_message_wrapper(
+                MessageType::Success,
+                Message::new(
+                    "Kafka".to_string(),
+                    format!("wrote {} streams to {}", names.len(), file_path.display()),
+                ),
+            );
+        }
+        SupportedLanguages::Python => {
+            let file_path = Path::new(path).join("external_topics.py");
+            let contents = render_python_streams(&names, &py_type_map);
+            fs::write(&file_path, contents.as_bytes()).map_err(|e| {
+                RoutineFailure::new(
+                    Message::new(
+                        "Kafka".to_string(),
+                        format!("writing {}", file_path.display()),
+                    ),
+                    e,
+                )
+            })?;
+            crate::cli::display::show_message_wrapper(
+                MessageType::Success,
+                Message::new(
+                    "Kafka".to_string(),
+                    format!("wrote {} streams to {}", names.len(), file_path.display()),
+                ),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn sanitize_ts_ident(topic: &str) -> String {
+    let mut ident = topic.to_case(Case::Pascal);
+    if ident.is_empty() || !ident.chars().next().unwrap().is_ascii_alphabetic() {
+        ident.insert(0, '_');
+    }
+    ident
+}
+
+fn sanitize_py_ident(topic: &str) -> String {
+    let mut ident = topic.to_case(Case::Snake);
+    if ident.is_empty() || !ident.chars().next().unwrap().is_ascii_alphabetic() {
+        ident.insert(0, '_');
+    }
+    ident
+}
+
+fn render_typescript_streams(
+    topics: &[String],
+    type_map: &std::collections::HashMap<String, (String, String)>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("// AUTO-GENERATED FILE. DO NOT EDIT.\n");
+    out.push_str("// This file will be replaced when you run `moose kafka pull`.\n\n");
+    out.push_str("import { Stream } from \"@514labs/moose-lib\";\n");
+    for (_topic, (type_name, file_stem)) in type_map.iter() {
+        out.push_str(&format!(
+            "import type {{ {type_name} }} from \"./{file_stem}\";\n"
+        ));
+    }
+    out.push_str("\n");
+
+    for t in topics {
+        let var_name = sanitize_ts_ident(t);
+        if let Some((type_name, _)) = type_map.get(t) {
+            out.push_str(&format!(
+                "export const {var_name} = new Stream<{type_name}>(\"{t}\");\n"
+            ));
+        } else {
+            out.push_str(&format!(
+                "export const {var_name} = new Stream<{{}}>(\"{t}\");\n"
+            ));
+        }
+    }
+    out
+}
+
+fn render_python_streams(
+    topics: &[String],
+    type_map: &std::collections::HashMap<String, (String, String)>,
+) -> String {
+    let mut out = String::new();
+    out.push_str("# AUTO-GENERATED FILE. DO NOT EDIT.\n");
+    out.push_str("# This file will be replaced when you run `moose kafka pull`.\n\n");
+    out.push_str("from moose_lib import Stream\n");
+    for (_topic, (class_name, module_stem)) in type_map.iter() {
+        out.push_str(&format!("from .{module_stem} import {class_name}\n"));
+    }
+    out.push_str("\n");
+
+    for t in topics {
+        let var_name = sanitize_py_ident(t);
+        if let Some((class_name, _)) = type_map.get(t) {
+            out.push_str(&format!("{var_name} = Stream[{class_name}](\"{t}\")\n"));
+        } else {
+            out.push_str(&format!("{var_name} = Stream(\"{t}\")\n"));
+        }
+    }
+    out
+}
+
+/// returns None if the
+async fn fetch_latest_json_schema(
+    client: &SchemaRegistryClient,
+    subject: &str,
+) -> Result<Option<String>, RoutineFailure> {
+    let meta = client.get_latest_version(subject, None).await;
+    let meta = match meta {
+        Ok(rs) => rs,
+        Err(SchemaRegistryError::ResponseError(r)) if r.status == 404 => return Ok(None),
+        Err(e) => {
+            return Err(RoutineFailure::new(
+                Message::new("Schema Registry".to_string(), "request failed".to_string()),
+                e,
+            ))
+        }
+    };
+    if !meta.schema_type.is_some_and(|t| t == "JSON") {
+        return Ok(None);
+    }
+    Ok(meta.schema)
+}
+
+fn generate_typescript_from_schema_named(
+    schema_json: &str,
+    out_path: &Path,
+    type_name: &str,
+) -> Result<(), anyhow::Error> {
+    let mut child = std::process::Command::new("npx")
+        .arg("--yes")
+        .arg("json-schema-to-typescript")
+        .arg("--stdin")
+        .arg("--no-banner")
+        .arg("--name")
+        .arg(type_name)
+        .arg("-o")
+        .arg(out_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(schema_json.as_bytes())?;
+    }
+    let output = child.wait_with_output()?;
+    println!("stdout {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr {}", String::from_utf8_lossy(&output.stderr));
+
+    if !output.status.success() {
+        anyhow::bail!("json-schema-to-typescript failed");
+    }
+    Ok(())
+}
+
+fn generate_python_from_schema_named(
+    schema_json: &str,
+    out_path: &Path,
+    class_name: &str,
+) -> Result<(), anyhow::Error> {
+    use std::io::Write;
+    // Write schema to a temp file because some versions of datamodel-codegen do not support '-' stdin
+    let mut tmp = tempfile::NamedTempFile::new()?;
+    tmp.write_all(schema_json.as_bytes())?;
+    tmp.flush()?;
+    let tmp_path = tmp.into_temp_path();
+
+    let mut cmd = std::process::Command::new("datamodel-codegen");
+    cmd.arg("--input")
+        .arg(tmp_path.to_path_buf())
+        .arg("--output")
+        .arg(out_path)
+        .arg("--input-file-type")
+        .arg("jsonschema")
+        .arg("--class-name")
+        .arg(class_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            crate::cli::display::show_message_wrapper(
+                MessageType::Highlight,
+                Message::new(
+                    "Python".to_string(),
+                    "datamodel-code-generator not found. Install with: pip install datamodel-code-generator".to_string(),
+                ),
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let output = child.wait_with_output()?;
+    println!("stdout {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr {}", String::from_utf8_lossy(&output.stderr));
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "datamodel-codegen failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}

--- a/apps/framework-cli/src/cli/routines/kafka_pull.rs
+++ b/apps/framework-cli/src/cli/routines/kafka_pull.rs
@@ -17,10 +17,7 @@ fn build_matcher(s: &str) -> Result<GlobMatcher, RoutineFailure> {
     let matcher = Glob::new(s)
         .map_err(|e| {
             RoutineFailure::new(
-                Message::new(
-                    "Kafka".to_string(),
-                    "invalid include glob for include".to_string(),
-                ),
+                Message::new("Kafka".to_string(), format!("invalid glob pattern: {s}")),
                 e,
             )
         })?
@@ -98,11 +95,9 @@ pub async fn write_external_topics(
                     }
                 },
                 Ok(None) => {
-                    println!("No such schema found for {}", topic);
-                    // No JSON schema for this subject
+                    info!("No JSON schema found for subject {}", subject);
                 }
                 Err(e) => {
-                    println!("Failed to fetch schema for {}: {:?}", subject, e);
                     warn!("Failed to fetch schema for {}: {:?}", subject, e);
                 }
             }
@@ -258,7 +253,7 @@ fn render_python_streams(
     out
 }
 
-/// returns None if the
+/// Returns None if the subject does not exist or schema type is not JSON.
 async fn fetch_latest_json_schema(
     client: &SchemaRegistryClient,
     subject: &str,

--- a/apps/framework-cli/src/cli/routines/kafka_pull.rs
+++ b/apps/framework-cli/src/cli/routines/kafka_pull.rs
@@ -209,8 +209,10 @@ fn render_typescript_streams(
     for t in topics {
         let var_name = sanitize_ts_ident(t);
         if let Some((type_name, _)) = type_map.get(t) {
+            // Include schema registry config (Latest subject) for topics with discovered JSON schema
+            let subject = format!("{}-value", t);
             out.push_str(&format!(
-                "export const {var_name} = new Stream<{type_name}>(\"{t}\", {{ lifeCycle: LifeCycle.EXTERNALLY_MANAGED }});\n"
+                "export const {var_name} = new Stream<{type_name}>(\"{t}\", {{ lifeCycle: LifeCycle.EXTERNALLY_MANAGED, schemaRegistry: {{ kind: \"JSON\", reference: {{ Latest: {{ subject_name: \"{subject}\" }} }} }} }});\n"
             ));
         } else {
             out.push_str(&format!(
@@ -245,7 +247,9 @@ fn render_python_streams(
     for t in topics {
         let var_name = sanitize_py_ident(t);
         if let Some((class_name, _)) = type_map.get(t) {
-            out.push_str(&format!("{var_name} = Stream[{class_name}](\"{t}\", StreamConfig(life_cycle=LifeCycle.EXTERNALLY_MANAGED))\n"));
+            // Include schema registry config (Latest subject) for topics with discovered JSON schema
+            let subject = format!("{}-value", t);
+            out.push_str(&format!("{var_name} = Stream[{class_name}](\"{t}\", StreamConfig(life_cycle=LifeCycle.EXTERNALLY_MANAGED, schema_registry={{\"kind\": \"JSON\", \"reference\": {{\"Latest\": {{\"subject_name\": \"{subject}\"}}}}}}))\n"));
         } else {
             out.push_str(&format!("{var_name} = Stream[EmptyModel](\"{t}\", StreamConfig(life_cycle=LifeCycle.EXTERNALLY_MANAGED))\n"));
         }

--- a/apps/framework-cli/src/cli/routines/kafka_pull.rs
+++ b/apps/framework-cli/src/cli/routines/kafka_pull.rs
@@ -11,7 +11,6 @@ use schema_registry_client::rest::schema_registry_client::{
     Client as SrClientTrait, SchemaRegistryClient,
 };
 use std::fs;
-use std::io::Write;
 use std::path::Path;
 
 fn build_matcher(s: &str) -> Result<GlobMatcher, RoutineFailure> {
@@ -71,6 +70,9 @@ pub async fn write_external_topics(
     // Build type maps by fetching schemas first (if configured)
     let mut ts_type_map: std::collections::HashMap<String, (String, String)> = Default::default();
     let mut py_type_map: std::collections::HashMap<String, (String, String)> = Default::default();
+    // Accumulate schemas to generate single-file outputs
+    let mut ts_schema_items: Vec<(String, String)> = Vec::new(); // (type_name, schema_json)
+    let mut py_schema_items: Vec<(String, String)> = Vec::new(); // (class_name, schema_json)
     if let Some(sr_url) = schema_registry {
         let config = schema_registry_client::rest::client_config::ClientConfig {
             base_urls: vec![sr_url.to_string()],
@@ -83,32 +85,16 @@ pub async fn write_external_topics(
                 Ok(Some(schema_json)) => match project.language {
                     SupportedLanguages::Typescript => {
                         let type_name = sanitize_ts_ident(topic);
-                        let file_stem = type_name.clone();
-                        let out = Path::new(path).join(format!("{file_stem}.ts"));
-                        if let Err(e) =
-                            generate_typescript_from_schema_named(&schema_json, &out, &type_name)
-                        {
-                            warn!("Failed to generate TS for {}: {:?}", subject, e);
-                        } else {
-                            ts_type_map.insert(topic.clone(), (type_name, file_stem));
-                        }
+                        ts_schema_items.push((type_name.clone(), schema_json));
+                        // All types will be emitted into a single file `externalTypes.ts`
+                        ts_type_map.insert(topic.clone(), (type_name, "externalTypes".to_string()));
                     }
                     SupportedLanguages::Python => {
-                        // Ensure package for relative imports
-                        let init_py = Path::new(path).join("__init__.py");
-                        if !init_py.exists() {
-                            let _ = fs::write(&init_py, b"");
-                        }
                         let class_name = sanitize_ts_ident(topic); // PascalCase class name
-                        let module_stem = sanitize_py_ident(topic);
-                        let out = Path::new(path).join(format!("{module_stem}.py"));
-                        if let Err(e) =
-                            generate_python_from_schema_named(&schema_json, &out, &class_name)
-                        {
-                            warn!("Failed to generate Python for {}: {:?}", subject, e);
-                        } else {
-                            py_type_map.insert(topic.clone(), (class_name, module_stem));
-                        }
+                        py_schema_items.push((class_name.clone(), schema_json));
+                        // All classes will be emitted into a single file `external_models.py`
+                        py_type_map
+                            .insert(topic.clone(), (class_name, "external_models".to_string()));
                     }
                 },
                 Ok(None) => {
@@ -118,6 +104,30 @@ pub async fn write_external_topics(
                 Err(e) => {
                     println!("Failed to fetch schema for {}: {:?}", subject, e);
                     warn!("Failed to fetch schema for {}: {:?}", subject, e);
+                }
+            }
+        }
+        // After collecting all schemas, write single-file outputs per language
+        match project.language {
+            SupportedLanguages::Typescript => {
+                if !ts_schema_items.is_empty() {
+                    let out = Path::new(path).join("externalTypes.ts");
+                    if let Err(e) = generate_typescript_bundle(&ts_schema_items, &out) {
+                        warn!("Failed to generate bundled TS types: {:?}", e);
+                    }
+                }
+            }
+            SupportedLanguages::Python => {
+                // Ensure package for relative imports
+                let init_py = Path::new(path).join("__init__.py");
+                if !init_py.exists() {
+                    let _ = fs::write(&init_py, b"");
+                }
+                if !py_schema_items.is_empty() {
+                    let out = Path::new(path).join("external_models.py");
+                    if let Err(e) = generate_python_bundle(&py_schema_items, &out) {
+                        warn!("Failed to generate bundled Python models: {:?}", e);
+                    }
                 }
             }
         }
@@ -199,7 +209,7 @@ fn render_typescript_streams(
             "import type {{ {type_name} }} from \"./{file_stem}\";\n"
         ));
     }
-    out.push_str("\n");
+    out.push('\n');
 
     for t in topics {
         let var_name = sanitize_ts_ident(t);
@@ -231,7 +241,7 @@ fn render_python_streams(
     for (_topic, (class_name, module_stem)) in type_map.iter() {
         out.push_str(&format!("from .{module_stem} import {class_name}\n"));
     }
-    out.push_str("\n");
+    out.push('\n');
     if needs_empty {
         out.push_str("class EmptyModel(BaseModel):\n");
         out.push_str("    pass\n\n");
@@ -264,90 +274,106 @@ async fn fetch_latest_json_schema(
             ))
         }
     };
-    if !meta.schema_type.is_some_and(|t| t == "JSON") {
+    if meta.schema_type.is_none_or(|t| t != "JSON") {
         return Ok(None);
     }
     Ok(meta.schema)
 }
 
-fn generate_typescript_from_schema_named(
-    schema_json: &str,
+fn generate_typescript_bundle(
+    schema_items: &[(String, String)],
     out_path: &Path,
-    type_name: &str,
-) -> Result<(), anyhow::Error> {
-    let mut child = std::process::Command::new("npx")
-        .arg("--yes")
-        .arg("json-schema-to-typescript")
-        .arg("--stdin")
-        .arg("--no-banner")
-        .arg("--name")
-        .arg(type_name)
-        .arg("-o")
-        .arg(out_path)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()?;
-    if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(schema_json.as_bytes())?;
-    }
-    let output = child.wait_with_output()?;
-    println!("stdout {}", String::from_utf8_lossy(&output.stdout));
-    println!("stderr {}", String::from_utf8_lossy(&output.stderr));
-
-    if !output.status.success() {
-        anyhow::bail!("json-schema-to-typescript failed");
-    }
-    Ok(())
-}
-
-fn generate_python_from_schema_named(
-    schema_json: &str,
-    out_path: &Path,
-    class_name: &str,
 ) -> Result<(), anyhow::Error> {
     use std::io::Write;
-    // Write schema to a temp file because some versions of datamodel-codegen do not support '-' stdin
-    let mut tmp = tempfile::NamedTempFile::new()?;
-    tmp.write_all(schema_json.as_bytes())?;
-    tmp.flush()?;
-    let tmp_path = tmp.into_temp_path();
-
-    let mut cmd = std::process::Command::new("datamodel-codegen");
-    cmd.arg("--input")
-        .arg(tmp_path.to_path_buf())
-        .arg("--output")
-        .arg(out_path)
-        .arg("--input-file-type")
-        .arg("jsonschema")
-        .arg("--class-name")
-        .arg(class_name)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
-
-    let child = match cmd.spawn() {
-        Ok(child) => child,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            crate::cli::display::show_message_wrapper(
-                MessageType::Highlight,
-                Message::new(
-                    "Python".to_string(),
-                    "datamodel-code-generator not found. Install with: pip install datamodel-code-generator".to_string(),
-                ),
-            );
-            return Ok(());
+    let mut combined = String::new();
+    for (type_name, schema_json) in schema_items {
+        let mut child = std::process::Command::new("npx")
+            .arg("--yes")
+            .arg("json-schema-to-typescript")
+            .arg("--stdin")
+            .arg("--no-banner")
+            .arg("--name")
+            .arg(type_name)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(schema_json.as_bytes())?;
         }
-        Err(e) => return Err(e.into()),
-    };
-    let output = child.wait_with_output()?;
-    println!("stdout {}", String::from_utf8_lossy(&output.stdout));
-    println!("stderr {}", String::from_utf8_lossy(&output.stderr));
-
-    if !output.status.success() {
-        anyhow::bail!(
-            "datamodel-codegen failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
+        let output = child.wait_with_output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "json-schema-to-typescript failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        if !combined.ends_with('\n') {
+            combined.push('\n');
+        }
     }
-    Ok(())
+    fs::write(out_path, combined.as_bytes()).map_err(|e| e.into())
+}
+
+fn generate_python_bundle(
+    schema_items: &[(String, String)],
+    out_path: &Path,
+) -> Result<(), anyhow::Error> {
+    use std::io::Write;
+    let mut combined = String::new();
+    for (class_name, schema_json) in schema_items {
+        // Write schema to a temp file because some versions of datamodel-codegen do not support '-' stdin
+        let mut tmp_schema = tempfile::NamedTempFile::new()?;
+        tmp_schema.write_all(schema_json.as_bytes())?;
+        tmp_schema.flush()?;
+        let tmp_schema_path = tmp_schema.into_temp_path();
+
+        // Create a temp output file to capture generated code
+        let tmp_out = tempfile::NamedTempFile::new()?;
+        let tmp_out_path = tmp_out.path().to_path_buf();
+        drop(tmp_out); // Allow the tool to write to this path
+
+        let mut cmd = std::process::Command::new("datamodel-codegen");
+        cmd.arg("--input")
+            .arg(&tmp_schema_path)
+            .arg("--output")
+            .arg(&tmp_out_path)
+            .arg("--input-file-type")
+            .arg("jsonschema")
+            .arg("--class-name")
+            .arg(class_name)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                crate::cli::display::show_message_wrapper(
+                    MessageType::Highlight,
+                    Message::new(
+                        "Python".to_string(),
+                        "datamodel-code-generator not found. Install with: pip install datamodel-code-generator".to_string(),
+                    ),
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let output = child.wait_with_output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "datamodel-codegen failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let code = fs::read_to_string(&tmp_out_path)?;
+        combined.push_str(&code);
+        if !combined.ends_with('\n') {
+            combined.push('\n');
+        }
+        // Best-effort cleanup; ignore errors
+        let _ = std::fs::remove_file(&tmp_out_path);
+    }
+    fs::write(out_path, combined.as_bytes()).map_err(|e| e.into())
 }

--- a/apps/framework-cli/src/cli/routines/kafka_pull.rs
+++ b/apps/framework-cli/src/cli/routines/kafka_pull.rs
@@ -243,7 +243,9 @@ fn render_python_streams(
     let mut out = String::new();
     out.push_str("# AUTO-GENERATED FILE. DO NOT EDIT.\n");
     out.push_str("# This file will be replaced when you run `moose kafka pull`.\n\n");
-    out.push_str("from moose_lib import Stream, StreamConfig, LifeCycle\n");
+    out.push_str(
+        "from moose_lib import Stream, StreamConfig, LifeCycle, KafkaSchemaConfig, SubjectLatest\n",
+    );
     let needs_empty = topics.iter().any(|t| !type_map.contains_key(t));
     if needs_empty {
         out.push_str("from pydantic import BaseModel\n");

--- a/apps/framework-cli/src/cli/routines/kafka_pull.rs
+++ b/apps/framework-cli/src/cli/routines/kafka_pull.rs
@@ -193,7 +193,7 @@ fn render_typescript_streams(
     let mut out = String::new();
     out.push_str("// AUTO-GENERATED FILE. DO NOT EDIT.\n");
     out.push_str("// This file will be replaced when you run `moose kafka pull`.\n\n");
-    out.push_str("import { Stream } from \"@514labs/moose-lib\";\n");
+    out.push_str("import { Stream, LifeCycle } from \"@514labs/moose-lib\";\n");
     for (_topic, (type_name, file_stem)) in type_map.iter() {
         out.push_str(&format!(
             "import type {{ {type_name} }} from \"./{file_stem}\";\n"
@@ -205,11 +205,11 @@ fn render_typescript_streams(
         let var_name = sanitize_ts_ident(t);
         if let Some((type_name, _)) = type_map.get(t) {
             out.push_str(&format!(
-                "export const {var_name} = new Stream<{type_name}>(\"{t}\");\n"
+                "export const {var_name} = new Stream<{type_name}>(\"{t}\", {{ lifeCycle: LifeCycle.EXTERNALLY_MANAGED }});\n"
             ));
         } else {
             out.push_str(&format!(
-                "export const {var_name} = new Stream<{{}}>(\"{t}\");\n"
+                "export const {var_name} = new Stream<{{}}>(\"{t}\", {{ lifeCycle: LifeCycle.EXTERNALLY_MANAGED }});\n"
             ));
         }
     }
@@ -223,7 +223,7 @@ fn render_python_streams(
     let mut out = String::new();
     out.push_str("# AUTO-GENERATED FILE. DO NOT EDIT.\n");
     out.push_str("# This file will be replaced when you run `moose kafka pull`.\n\n");
-    out.push_str("from moose_lib import Stream\n");
+    out.push_str("from moose_lib import Stream, StreamConfig, LifeCycle\n");
     let needs_empty = topics.iter().any(|t| !type_map.contains_key(t));
     if needs_empty {
         out.push_str("from pydantic import BaseModel\n");
@@ -240,9 +240,9 @@ fn render_python_streams(
     for t in topics {
         let var_name = sanitize_py_ident(t);
         if let Some((class_name, _)) = type_map.get(t) {
-            out.push_str(&format!("{var_name} = Stream[{class_name}](\"{t}\")\n"));
+            out.push_str(&format!("{var_name} = Stream[{class_name}](\"{t}\", StreamConfig(life_cycle=LifeCycle.EXTERNALLY_MANAGED))\n"));
         } else {
-            out.push_str(&format!("{var_name} = Stream[EmptyModel](\"{t}\")\n"));
+            out.push_str(&format!("{var_name} = Stream[EmptyModel](\"{t}\", StreamConfig(life_cycle=LifeCycle.EXTERNALLY_MANAGED))\n"));
         }
     }
     out

--- a/apps/framework-cli/src/framework/bulk_import.rs
+++ b/apps/framework-cli/src/framework/bulk_import.rs
@@ -2,7 +2,6 @@ use crate::framework::core::infrastructure::api_endpoint::APIType;
 use crate::framework::core::infrastructure::table::ColumnType;
 use anyhow::bail;
 use itertools::Itertools;
-use serde::__private::from_utf8_lossy;
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::Path;
@@ -105,7 +104,7 @@ pub async fn import_csv_file(
         let status = res.status();
         if status != 200 {
             let body = match res.bytes().await {
-                Ok(bytes) => from_utf8_lossy(&bytes).to_string(),
+                Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
                 Err(e) => format!("Getting body failed: {e}"),
             };
             bail!("Import failure with status {}: {}", status, body)

--- a/apps/framework-cli/src/framework/core/infrastructure/topic.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/topic.rs
@@ -188,7 +188,7 @@ fn kafka_schema_to_proto(s: &KafkaSchema) -> ProtoSchemaRegistry {
         "PROTOBUF" => crate::proto::infrastructure_map::schema_registry::Encoding::PROTOBUF.into(),
         _ => crate::proto::infrastructure_map::schema_registry::Encoding::JSON.into(),
     };
-    use crate::proto::infrastructure_map::schema_registry::SchemaRef as ProtoSchemaRef;
+    use crate::proto::infrastructure_map::schema_registry::Schema_ref as ProtoSchemaRef;
     sr.schema_ref = Some(match &s.reference {
         SchemaResgistryReference::Id(id) => ProtoSchemaRef::SchemaId(*id as u32),
         SchemaResgistryReference::Latest { subject_name } => {
@@ -215,13 +215,13 @@ fn proto_to_kafka_schema(sr: ProtoSchemaRegistry) -> Option<KafkaSchema> {
 
     let r = sr.schema_ref?;
     let reference = match r {
-        crate::proto::infrastructure_map::schema_registry::SchemaRef::SchemaId(id) => {
+        crate::proto::infrastructure_map::schema_registry::Schema_ref::SchemaId(id) => {
             SchemaResgistryReference::Id(id as u8)
         }
-        crate::proto::infrastructure_map::schema_registry::SchemaRef::Subject(s) => {
+        crate::proto::infrastructure_map::schema_registry::Schema_ref::Subject(s) => {
             SchemaResgistryReference::Latest { subject_name: s }
         }
-        crate::proto::infrastructure_map::schema_registry::SchemaRef::SubjectVersion(sv) => {
+        crate::proto::infrastructure_map::schema_registry::Schema_ref::SubjectVersion(sv) => {
             SchemaResgistryReference::SubjectVersion {
                 name: sv.subject,
                 version: sv.version as u8,

--- a/apps/framework-cli/src/framework/core/infrastructure/topic.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/topic.rs
@@ -52,9 +52,9 @@ pub struct KafkaSchema {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SchemaResgistryReference {
-    Id(u8),
+    Id(i32),
     Latest { subject_name: String },
-    SubjectVersion { name: String, version: u8 },
+    SubjectVersion { name: String, version: i32 },
 }
 
 impl Topic {
@@ -190,14 +190,14 @@ fn kafka_schema_to_proto(s: &KafkaSchema) -> ProtoSchemaRegistry {
     };
     use crate::proto::infrastructure_map::schema_registry::Schema_ref as ProtoSchemaRef;
     sr.schema_ref = Some(match &s.reference {
-        SchemaResgistryReference::Id(id) => ProtoSchemaRef::SchemaId(*id as u32),
+        SchemaResgistryReference::Id(id) => ProtoSchemaRef::SchemaId(*id),
         SchemaResgistryReference::Latest { subject_name } => {
             ProtoSchemaRef::Subject(subject_name.clone())
         }
         SchemaResgistryReference::SubjectVersion { name, version } => {
             let mut sv = ProtoSubjectVersion::new();
             sv.subject = name.clone();
-            sv.version = *version as u32;
+            sv.version = *version;
             ProtoSchemaRef::SubjectVersion(sv)
         }
     });
@@ -216,7 +216,7 @@ fn proto_to_kafka_schema(sr: ProtoSchemaRegistry) -> Option<KafkaSchema> {
     let r = sr.schema_ref?;
     let reference = match r {
         crate::proto::infrastructure_map::schema_registry::Schema_ref::SchemaId(id) => {
-            SchemaResgistryReference::Id(id as u8)
+            SchemaResgistryReference::Id(id)
         }
         crate::proto::infrastructure_map::schema_registry::Schema_ref::Subject(s) => {
             SchemaResgistryReference::Latest { subject_name: s }
@@ -224,7 +224,7 @@ fn proto_to_kafka_schema(sr: ProtoSchemaRegistry) -> Option<KafkaSchema> {
         crate::proto::infrastructure_map::schema_registry::Schema_ref::SubjectVersion(sv) => {
             SchemaResgistryReference::SubjectVersion {
                 name: sv.subject,
-                version: sv.version as u8,
+                version: sv.version,
             }
         }
     };

--- a/apps/framework-cli/src/framework/core/infrastructure/topic.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/topic.rs
@@ -37,14 +37,13 @@ pub struct Topic {
     #[serde(default = "LifeCycle::default_for_deserialization")]
     pub life_cycle: LifeCycle,
 
-    /// Optional minimal Schema Registry configuration.
     #[serde(default)]
     pub schema_registry: Option<KafkaSchema>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSchema {
-    /// Encoding/wire format (e.g. "JSON", "AVRO", "PROTOBUF")
+    /// Schema type (only "JSON" supported currently)
     pub kind: String,
     /// Reference sum type
     pub reference: SchemaResgistryReference,

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -3641,7 +3641,7 @@ mod diff_topic_tests {
             }],
             metadata: None,
             life_cycle: LifeCycle::FullyManaged,
-            schema_registry: None,
+            schema_config: None,
         }
     }
 

--- a/apps/framework-cli/src/framework/core/infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure_map.rs
@@ -3584,6 +3584,7 @@ mod diff_topic_tests {
             }],
             metadata: None,
             life_cycle: LifeCycle::FullyManaged,
+            schema_registry: None,
         }
     }
 

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -60,7 +60,7 @@ use super::{
         orchestration_worker::OrchestrationWorker,
         sql_resource::SqlResource,
         table::{Column, Metadata, Table},
-        topic::{Topic, DEFAULT_MAX_MESSAGE_BYTES},
+        topic::{KafkaSchema, Topic, DEFAULT_MAX_MESSAGE_BYTES},
         topic_sync_process::{TopicToTableSyncProcess, TopicToTopicSyncProcess},
         view::View,
     },
@@ -179,6 +179,9 @@ struct PartialTopic {
     pub consumers: Vec<Consumer>,
     pub metadata: Option<Metadata>,
     pub life_cycle: Option<LifeCycle>,
+    /// Optional minimal Schema Registry config passthrough from TS/Py
+    #[serde(default)]
+    pub schema_registry: Option<KafkaSchema>,
 }
 
 /// Specifies the type of destination for write operations.
@@ -605,6 +608,7 @@ impl PartialInfrastructureMap {
                     },
                     metadata: partial_topic.metadata.clone(),
                     life_cycle: partial_topic.life_cycle.unwrap_or(LifeCycle::FullyManaged),
+                    schema_registry: partial_topic.schema_registry.clone(),
                 };
                 (topic.id(), topic)
             })

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -180,7 +180,7 @@ struct PartialTopic {
     pub metadata: Option<Metadata>,
     pub life_cycle: Option<LifeCycle>,
     #[serde(default)]
-    pub schema_registry: Option<KafkaSchema>,
+    pub schema_config: Option<KafkaSchema>,
 }
 
 /// Specifies the type of destination for write operations.
@@ -607,7 +607,7 @@ impl PartialInfrastructureMap {
                     },
                     metadata: partial_topic.metadata.clone(),
                     life_cycle: partial_topic.life_cycle.unwrap_or(LifeCycle::FullyManaged),
-                    schema_registry: partial_topic.schema_registry.clone(),
+                    schema_config: partial_topic.schema_config.clone(),
                 };
                 (topic.id(), topic)
             })

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -179,7 +179,6 @@ struct PartialTopic {
     pub consumers: Vec<Consumer>,
     pub metadata: Option<Metadata>,
     pub life_cycle: Option<LifeCycle>,
-    /// Optional minimal Schema Registry config passthrough from TS/Py
     #[serde(default)]
     pub schema_registry: Option<KafkaSchema>,
 }

--- a/apps/framework-cli/src/infrastructure/olap/clickhouse_alt_client.rs
+++ b/apps/framework-cli/src/infrastructure/olap/clickhouse_alt_client.rs
@@ -22,7 +22,6 @@ use futures::StreamExt;
 use itertools::{Either, Itertools};
 use log::{info, warn};
 use serde::Serialize;
-use serde::__private::from_utf8_lossy;
 use serde_json::{json, Map, Value};
 
 use crate::framework::core::infrastructure::table::EnumValue;
@@ -96,7 +95,7 @@ fn value_to_json(
         ValueRef::Int64(v) => json!(v),
         // TODO: base64 encode if type is Bytes (probably Uint8Array in TS)
         // In clickhouse the String type means arbitrary bytes
-        ValueRef::String(v) => json!(from_utf8_lossy(v)),
+        ValueRef::String(v) => json!(String::from_utf8_lossy(v)),
         ValueRef::Float32(v) => json!(v),
         ValueRef::Float64(v) => json!(v),
         ValueRef::Date(v) => {

--- a/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
+++ b/apps/framework-cli/src/infrastructure/processes/kafka_clickhouse_sync.rs
@@ -321,38 +321,46 @@ async fn sync_kafka_to_kafka(
             }
 
             Ok(message) => match message.payload() {
-                Some(payload) => match std::str::from_utf8(payload) {
-                    Ok(payload_str) => {
-                        log::trace!(
-                            "Received message from {}: {}",
-                            source_topic_name,
-                            payload_str
-                        );
-                        metrics
-                            .send_metric_event(MetricEvent::TopicToOLAPEvent {
-                                timestamp: chrono::Utc::now(),
-                                count: 1,
-                                bytes: payload.len() as u64,
-                                consumer_group: "clickhouse sync".to_string(),
-                                topic_name: source_topic_name.clone(),
-                            })
-                            .await;
+                Some(payload) => {
+                    // Strip Schema Registry JSON envelope if present: 0x00 + 4-byte schema ID
+                    let payload = if payload.len() >= 5 && payload[0] == 0x00 {
+                        &payload[5..]
+                    } else {
+                        payload
+                    };
+                    match std::str::from_utf8(payload) {
+                        Ok(payload_str) => {
+                            log::trace!(
+                                "Received message from {}: {}",
+                                source_topic_name,
+                                payload_str
+                            );
+                            metrics
+                                .send_metric_event(MetricEvent::TopicToOLAPEvent {
+                                    timestamp: chrono::Utc::now(),
+                                    count: 1,
+                                    bytes: payload.len() as u64,
+                                    consumer_group: "clickhouse sync".to_string(),
+                                    topic_name: source_topic_name.clone(),
+                                })
+                                .await;
 
-                        send_with_back_pressure(
-                            &mut queue,
-                            &producer.producer,
-                            target_topic_name,
-                            payload_str.to_string(),
-                        )
-                        .await;
+                            send_with_back_pressure(
+                                &mut queue,
+                                &producer.producer,
+                                target_topic_name,
+                                payload_str.to_string(),
+                            )
+                            .await;
+                        }
+                        Err(_) => {
+                            error!(
+                                "Received message from {} with invalid UTF-8",
+                                source_topic_name
+                            );
+                        }
                     }
-                    Err(_) => {
-                        error!(
-                            "Received message from {} with invalid UTF-8",
-                            source_topic_name
-                        );
-                    }
-                },
+                }
                 None => {
                     debug!(
                         "Received message from {} with no payload",
@@ -451,39 +459,43 @@ async fn sync_kafka_to_clickhouse(
                     }
 
                     Ok(message) => match message.payload() {
-                        Some(payload) => match std::str::from_utf8(payload) {
-                            Ok(payload_str) => {
-                                log::trace!(
-                                    "Received message from {}: {}",
-                                    source_topic_name, payload_str
-                                );
-                                metrics
-                                    .send_metric_event(MetricEvent::TopicToOLAPEvent {
-                                        timestamp: chrono::Utc::now(),
-                                        count: 1,
-                                        bytes: payload.len() as u64,
-                                        consumer_group: "clickhouse sync".to_string(),
-                                        topic_name: source_topic_name.clone(),
-                                    })
-                                    .await;
+                        Some(payload) => {
+                            // Strip Schema Registry JSON envelope if present: 0x00 + 4-byte schema ID
+                            let payload = if payload.len() >= 5 && payload[0] == 0x00 { &payload[5..] } else { payload };
+                            match std::str::from_utf8(payload) {
+                                Ok(payload_str) => {
+                                    log::trace!(
+                                        "Received message from {}: {}",
+                                        source_topic_name, payload_str
+                                    );
+                                    metrics
+                                        .send_metric_event(MetricEvent::TopicToOLAPEvent {
+                                            timestamp: chrono::Utc::now(),
+                                            count: 1,
+                                            bytes: payload.len() as u64,
+                                            consumer_group: "clickhouse sync".to_string(),
+                                            topic_name: source_topic_name.clone(),
+                                        })
+                                        .await;
 
-                                if let Ok(json_value) = serde_json::from_str(payload_str) {
-                                    if let Ok(clickhouse_record) =
-                                        mapper_json_to_clickhouse_record(&source_topic_columns, json_value)
-                                    {
-                                        inserter.insert(
-                                            clickhouse_record,
-                                            message.partition(),
-                                            message.offset(),
-                                        );
+                                    if let Ok(json_value) = serde_json::from_str(payload_str) {
+                                        if let Ok(clickhouse_record) =
+                                            mapper_json_to_clickhouse_record(&source_topic_columns, json_value)
+                                        {
+                                            inserter.insert(
+                                                clickhouse_record,
+                                                message.partition(),
+                                                message.offset(),
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                            Err(_) => {
-                                error!(
-                                    "Received message from {} with invalid UTF-8",
-                                    source_topic_name
-                                );
+                                Err(_) => {
+                                    error!(
+                                        "Received message from {} with invalid UTF-8",
+                                        source_topic_name
+                                    );
+                                }
                             }
                         },
                         None => {

--- a/apps/framework-cli/src/infrastructure/stream/kafka/models.rs
+++ b/apps/framework-cli/src/infrastructure/stream/kafka/models.rs
@@ -128,6 +128,9 @@ impl KafkaStreamConfig {
 pub struct KafkaConfig {
     /// Broker connection string in format "host:port"
     pub broker: String,
+    /// Optional Schema Registry base URL (e.g., http://localhost:8081)
+    #[serde(default)]
+    pub schema_registry_url: Option<String>,
     /// Message timeout in milliseconds
     pub message_timeout_ms: i32,
     /// Default retention period in milliseconds
@@ -299,6 +302,7 @@ impl Default for KafkaConfig {
     fn default() -> Self {
         Self {
             broker: "localhost:19092".to_string(),
+            schema_registry_url: None,
             message_timeout_ms: 1000,
             retention_ms: 30000,
             replication_factor: 1,

--- a/apps/framework-cli/src/utilities/validate_passthrough.rs
+++ b/apps/framework-cli/src/utilities/validate_passthrough.rs
@@ -508,8 +508,16 @@ impl<'de, S: SerializeValue> Visitor<'de> for &mut ValueVisitor<'_, S> {
                     .map_err(A::Error::custom)
             }
             t => {
-                if matches!(t, ColumnType::Float(_)) {
+                if matches!(
+                    t,
+                    ColumnType::Float(_)
+                        | ColumnType::Decimal { .. }
+                        | ColumnType::Int(_)
+                        | ColumnType::BigInt
+                ) {
                     use serde::Deserialize;
+                    // arbitrary precision number is passed to deserializing visitors
+                    // as a map with single string field "$serde_json::private::Number"
                     let arbitrary_precision = Number::deserialize(MapAccessWrapper {
                         map,
                         _phantom_data: &PHANTOM_DATA,

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -37,7 +37,7 @@ message Topic {
   optional int32 max_message_bytes = 7;
   Metadata metadata = 8;
   LifeCycle life_cycle = 9;
-  // Optional minimal Schema Registry configuration
+  // Optional Schema Registry configuration
   optional SchemaRegistry schema_registry = 10;
 }
 

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -41,7 +41,7 @@ message Topic {
   optional SchemaRegistry schema_registry = 10;
 }
 
-// Encodes minimal schema reference used for Schema Registry integration
+// Encodes schema reference used for Schema Registry integration
 message SchemaRegistry {
   enum Encoding {
     JSON = 0;

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -37,6 +37,32 @@ message Topic {
   optional int32 max_message_bytes = 7;
   Metadata metadata = 8;
   LifeCycle life_cycle = 9;
+  // Optional minimal Schema Registry configuration
+  optional SchemaRegistry schema_registry = 10;
+}
+
+// Encodes minimal schema reference used for Schema Registry integration
+message SchemaRegistry {
+  enum Encoding {
+    JSON = 0;
+    AVRO = 1;
+    PROTOBUF = 2;
+  }
+  // Encoding/wire format; avoid reserved names in generators
+  Encoding encoding = 1;
+  oneof schema_ref {
+    // Use a concrete schema ID
+    uint32 schema_id = 2;
+    // Use subject name (latest version)
+    string subject = 3;
+    // Use subject name with explicit version
+    SubjectVersion subject_version = 4;
+  }
+}
+
+message SubjectVersion {
+  string subject = 1;
+  uint32 version = 2;
 }
 
 message ApiEndpoint {

--- a/packages/protobuf/infrastructure_map.proto
+++ b/packages/protobuf/infrastructure_map.proto
@@ -52,7 +52,7 @@ message SchemaRegistry {
   Encoding encoding = 1;
   oneof schema_ref {
     // Use a concrete schema ID
-    uint32 schema_id = 2;
+    int32 schema_id = 2;
     // Use subject name (latest version)
     string subject = 3;
     // Use subject name with explicit version
@@ -62,7 +62,7 @@ message SchemaRegistry {
 
 message SubjectVersion {
   string subject = 1;
-  uint32 version = 2;
+  int32 version = 2;
 }
 
 message ApiEndpoint {

--- a/packages/py-moose-lib/moose_lib/config/config_file.py
+++ b/packages/py-moose-lib/moose_lib/config/config_file.py
@@ -32,6 +32,7 @@ class KafkaConfig:
     sasl_mechanism: Optional[str] = None
     security_protocol: Optional[str] = None
     namespace: Optional[str] = None
+    schema_registry_url: Optional[str] = None
 
 
 @dataclass
@@ -103,6 +104,7 @@ def read_project_config() -> ProjectConfig:
                 sasl_mechanism=sec.get("sasl_mechanism"),
                 security_protocol=sec.get("security_protocol"),
                 namespace=sec.get("namespace"),
+                schema_registry_url=sec.get("schema_registry_url"),
             )
 
         kafka_cfg = _parse_kafka("kafka_config")

--- a/packages/py-moose-lib/moose_lib/config/runtime.py
+++ b/packages/py-moose-lib/moose_lib/config/runtime.py
@@ -30,6 +30,7 @@ class RuntimeKafkaConfig:
     sasl_mechanism: Optional[str]
     security_protocol: Optional[str]
     namespace: Optional[str]
+    schema_registry_url: Optional[str]
 
 
 class ConfigurationRegistry:
@@ -160,6 +161,9 @@ class ConfigurationRegistry:
                                 _env("MOOSE_KAFKA_CONFIG__SECURITY_PROTOCOL")
             namespace = _env("MOOSE_REDPANDA_CONFIG__NAMESPACE") or \
                         _env("MOOSE_KAFKA_CONFIG__NAMESPACE")
+            schema_registry_url = _env("MOOSE_REDPANDA_CONFIG__SCHEMA_REGISTRY_URL") or \
+                                  _env("MOOSE_KAFKA_CONFIG__SCHEMA_REGISTRY_URL") or \
+                                  _env("SCHEMA_REGISTRY_URL")
 
             file_kafka = config.kafka_config
 
@@ -181,6 +185,8 @@ class ConfigurationRegistry:
                 security_protocol=security_protocol if security_protocol is not None else (
                     file_kafka.security_protocol if file_kafka else None),
                 namespace=namespace if namespace is not None else (file_kafka.namespace if file_kafka else None),
+                schema_registry_url=schema_registry_url if schema_registry_url is not None else (
+                    file_kafka.schema_registry_url if file_kafka else None),
             )
         except Exception as e:
             raise RuntimeError(f"Failed to get Kafka configuration: {e}")

--- a/packages/py-moose-lib/moose_lib/config/runtime.py
+++ b/packages/py-moose-lib/moose_lib/config/runtime.py
@@ -162,8 +162,7 @@ class ConfigurationRegistry:
             namespace = _env("MOOSE_REDPANDA_CONFIG__NAMESPACE") or \
                         _env("MOOSE_KAFKA_CONFIG__NAMESPACE")
             schema_registry_url = _env("MOOSE_REDPANDA_CONFIG__SCHEMA_REGISTRY_URL") or \
-                                  _env("MOOSE_KAFKA_CONFIG__SCHEMA_REGISTRY_URL") or \
-                                  _env("SCHEMA_REGISTRY_URL")
+                                  _env("MOOSE_KAFKA_CONFIG__SCHEMA_REGISTRY_URL")
 
             file_kafka = config.kafka_config
 

--- a/packages/py-moose-lib/moose_lib/dmv2/__init__.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/__init__.py
@@ -28,6 +28,10 @@ from .stream import (
     Stream,
     DeadLetterModel,
     DeadLetterQueue,
+    SubjectLatest,
+    SubjectVersion,
+    SchemaById,
+    KafkaSchemaConfig,
 )
 
 from .ingest_api import (
@@ -117,6 +121,11 @@ __all__ = [
     'Stream',
     'DeadLetterModel',
     'DeadLetterQueue',
+    'SubjectLatest',
+    'SubjectVersion',
+    'SchemaById',
+    'KafkaSchemaConfig',
+    'KafkaSchemaConfig',
 
     # Ingestion
     'IngestConfig',

--- a/packages/py-moose-lib/moose_lib/dmv2/__init__.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/__init__.py
@@ -125,7 +125,6 @@ __all__ = [
     'SubjectVersion',
     'SchemaById',
     'KafkaSchemaConfig',
-    'KafkaSchemaConfig',
 
     # Ingestion
     'IngestConfig',

--- a/packages/py-moose-lib/moose_lib/dmv2/stream.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/stream.py
@@ -349,7 +349,7 @@ class Stream(TypedMooseResource, Generic[T]):
         producer, cfg = self._get_memoized_producer()
         topic = self._build_full_topic_name(cfg.namespace)
 
-        sr = self.config.schema_registry
+        sr = self.config.schema_config
         if sr is not None:
             if sr.kind != "JSON":
                 raise NotImplementedError("Currently JSON Schema is supported.")

--- a/packages/py-moose-lib/moose_lib/dmv2/stream.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/stream.py
@@ -8,6 +8,9 @@ import dataclasses
 import datetime
 import json
 from typing import Any, Optional, Callable, Union, Literal, Generic
+from pydantic import BaseModel
+
+
 class LatestRef(BaseModel):
     subject_name: str
 
@@ -37,6 +40,7 @@ class SchemaRegistryReference(BaseModel):
 class KafkaSchema(BaseModel):
     kind: Literal["JSON", "AVRO", "PROTOBUF"]
     reference: SchemaRegistryReference
+
 
 from pydantic import BaseModel, ConfigDict, AliasGenerator
 from pydantic.alias_generators import to_camel

--- a/packages/py-moose-lib/moose_lib/dmv2/stream.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/stream.py
@@ -59,7 +59,7 @@ class StreamConfig(BaseModel):
     default_dead_letter_queue: "Optional[DeadLetterQueue]" = None
     # allow DeadLetterQueue
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    schema_registry: Optional[KafkaSchemaConfig] = None
+    schema_config: Optional[KafkaSchemaConfig] = None
 
 
 class TransformConfig(BaseModel):

--- a/packages/py-moose-lib/moose_lib/dmv2/stream.py
+++ b/packages/py-moose-lib/moose_lib/dmv2/stream.py
@@ -288,7 +288,7 @@ class Stream(TypedMooseResource, Generic[T]):
 
         brokers = self._parse_brokers(cfg.broker)
         if not brokers:
-            raise RuntimeError(f"No valid broker addresses found in: '{getattr(cfg, 'broker', '')}'")
+            raise RuntimeError(f"No valid broker addresses found in: '{cfg.broker}'")
 
         producer = get_kafka_producer(
             broker=brokers,
@@ -371,7 +371,7 @@ class Stream(TypedMooseResource, Generic[T]):
             elif isinstance(sr.reference, SubjectLatest):
                 schema = client.get_latest_version(sr.reference.name).schema
             else:
-                schema = client.get_version(sr.reference.name, sr.reference.version).schema
+                schema = client.get_version(sr.reference.subject, sr.reference.version).schema
 
             serializer = JSONSerializer(schema, client)
 

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -164,7 +164,7 @@ class TopicConfig(BaseModel):
     consumers: List[Consumer]
     metadata: Optional[dict] = None
     life_cycle: Optional[str] = None
-    schema_registry: Optional[KafkaSchemaConfig] = None
+    schema_config: Optional[KafkaSchemaConfig] = None
 
 
 class IngestApiConfig(BaseModel):
@@ -479,7 +479,7 @@ def to_infra_map() -> dict:
             consumers=consumers,
             metadata=getattr(stream, "metadata", None),
             life_cycle=stream.config.life_cycle.value if stream.config.life_cycle else None,
-            schema_registry=stream.config.schema_config,
+            schema_config=stream.config.schema_config,
         )
 
     for name, api in get_ingest_apis().items():

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -479,7 +479,7 @@ def to_infra_map() -> dict:
             consumers=consumers,
             metadata=getattr(stream, "metadata", None),
             life_cycle=stream.config.life_cycle.value if stream.config.life_cycle else None,
-            schema_registry=stream.config.schema_registry,
+            schema_registry=stream.config.schema_config,
         )
 
     for name, api in get_ingest_apis().items():

--- a/packages/py-moose-lib/moose_lib/internal.py
+++ b/packages/py-moose-lib/moose_lib/internal.py
@@ -24,14 +24,9 @@ from moose_lib.dmv2 import (
     MaterializedView,
     SqlResource
 )
+from moose_lib.dmv2.stream import KafkaSchemaConfig
 from pydantic.alias_generators import to_camel
 from pydantic.json_schema import JsonSchemaValue
-
-try:
-    # Import for type hints without creating runtime cycles
-    from moose_lib.dmv2.stream import KafkaSchema as _KafkaSchema
-except Exception:
-    _KafkaSchema = Any  # fallback for type checker/runtime if import cycle
 
 model_config = ConfigDict(alias_generator=AliasGenerator(
     serialization_alias=to_camel,
@@ -169,8 +164,7 @@ class TopicConfig(BaseModel):
     consumers: List[Consumer]
     metadata: Optional[dict] = None
     life_cycle: Optional[str] = None
-    # Optional minimal Schema Registry config; typed to KafkaSchema
-    schema_registry: Optional[_KafkaSchema] = None
+    schema_registry: Optional[KafkaSchemaConfig] = None
 
 
 class IngestApiConfig(BaseModel):
@@ -485,7 +479,7 @@ def to_infra_map() -> dict:
             consumers=consumers,
             metadata=getattr(stream, "metadata", None),
             life_cycle=stream.config.life_cycle.value if stream.config.life_cycle else None,
-            schema_registry=getattr(stream.config, "schema_registry", None),
+            schema_registry=stream.config.schema_registry,
         )
 
     for name, api in get_ingest_apis().items():

--- a/packages/py-moose-lib/setup.py
+++ b/packages/py-moose-lib/setup.py
@@ -33,5 +33,6 @@ setup(
         "clickhouse_connect>=0.7.16",
         "requests>=2.32.3",
         "sqlglot[rs]>=27.16.3",
+        "confluent-kafka[json,schemaregistry]>=2.11.1"
     ],
 )

--- a/packages/ts-moose-lib/package.json
+++ b/packages/ts-moose-lib/package.json
@@ -43,6 +43,7 @@
     "fastq": "1.17.1",
     "jose": "5.9.2",
     "@confluentinc/kafka-javascript": "1.5.0",
+    "@kafkajs/confluent-schema-registry": "3.9.0",
     "pretty-ms": "9.2.0",
     "redis": "^4.6.13",
     "toml": "3.0.0",

--- a/packages/ts-moose-lib/src/config/configFile.ts
+++ b/packages/ts-moose-lib/src/config/configFile.ts
@@ -36,6 +36,8 @@ export interface KafkaConfig {
   security_protocol?: string;
   /** Optional namespace used as a prefix for topics */
   namespace?: string;
+  /** Optional Confluent Schema Registry URL */
+  schema_registry_url?: string;
 }
 
 /**

--- a/packages/ts-moose-lib/src/config/runtime.ts
+++ b/packages/ts-moose-lib/src/config/runtime.ts
@@ -190,8 +190,7 @@ class ConfigurationRegistry {
       this._env("MOOSE_KAFKA_CONFIG__NAMESPACE");
     const envSchemaRegistryUrl =
       this._env("MOOSE_REDPANDA_CONFIG__SCHEMA_REGISTRY_URL") ??
-      this._env("MOOSE_KAFKA_CONFIG__SCHEMA_REGISTRY_URL") ??
-      this._env("SCHEMA_REGISTRY_URL");
+      this._env("MOOSE_KAFKA_CONFIG__SCHEMA_REGISTRY_URL");
 
     const fileKafka =
       projectConfig.kafka_config ?? projectConfig.redpanda_config;

--- a/packages/ts-moose-lib/src/config/runtime.ts
+++ b/packages/ts-moose-lib/src/config/runtime.ts
@@ -17,6 +17,7 @@ interface RuntimeKafkaConfig {
   saslMechanism?: string;
   securityProtocol?: string;
   namespace?: string;
+  schemaRegistryUrl?: string;
 }
 
 class ConfigurationRegistry {
@@ -121,6 +122,10 @@ class ConfigurationRegistry {
     const envNamespace =
       this._env("MOOSE_REDPANDA_CONFIG__NAMESPACE") ??
       this._env("MOOSE_KAFKA_CONFIG__NAMESPACE");
+    const envSchemaRegistryUrl =
+      this._env("MOOSE_REDPANDA_CONFIG__SCHEMA_REGISTRY_URL") ??
+      this._env("MOOSE_KAFKA_CONFIG__SCHEMA_REGISTRY_URL") ??
+      this._env("SCHEMA_REGISTRY_URL");
 
     const fileKafka =
       projectConfig.kafka_config ?? projectConfig.redpanda_config;
@@ -136,6 +141,7 @@ class ConfigurationRegistry {
       saslMechanism: envSaslMechanism ?? fileKafka?.sasl_mechanism,
       securityProtocol: envSecurityProtocol ?? fileKafka?.security_protocol,
       namespace: envNamespace ?? fileKafka?.namespace,
+      schemaRegistryUrl: envSchemaRegistryUrl ?? fileKafka?.schema_registry_url,
     };
   }
 

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -163,7 +163,7 @@ interface StreamJson {
   /** Lifecycle management setting for the stream. */
   lifeCycle?: string;
   /** Optional minimal Schema Registry config */
-  schemaRegistry?: SchemaRegistryJson;
+  schema_config?: SchemaRegistryJson;
 }
 /**
  * JSON representation of an Ingest API configuration.
@@ -395,7 +395,7 @@ export const toInfraMap = (registry: typeof moose_internal) => {
       consumers,
       metadata,
       lifeCycle: stream.config.lifeCycle,
-      schemaRegistry: (stream.config as any).schemaRegistry,
+      schemaConfig: stream.config.schemaConfig,
     };
   });
 

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -127,6 +127,16 @@ interface Consumer {
 /**
  * JSON representation of a Stream/Topic configuration.
  */
+type SchemaRegistryReferenceJson =
+  | { Id: number }
+  | { Latest: { subject_name: string } }
+  | { SubjectVersion: { name: string; version: number } };
+
+interface SchemaRegistryJson {
+  kind: "JSON" | "AVRO" | "PROTOBUF";
+  reference: SchemaRegistryReferenceJson;
+}
+
 interface StreamJson {
   /** The name of the stream/topic. */
   name: string;
@@ -152,6 +162,8 @@ interface StreamJson {
   metadata?: { description?: string };
   /** Lifecycle management setting for the stream. */
   lifeCycle?: string;
+  /** Optional minimal Schema Registry config */
+  schemaRegistry?: SchemaRegistryJson;
 }
 /**
  * JSON representation of an Ingest API configuration.
@@ -383,6 +395,7 @@ export const toInfraMap = (registry: typeof moose_internal) => {
       consumers,
       metadata,
       lifeCycle: stream.config.lifeCycle,
+      schemaRegistry: (stream.config as any).schemaRegistry,
     };
   });
 

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -17,7 +17,12 @@ import { IJsonSchemaCollection } from "typia/src/schemas/json/IJsonSchemaCollect
 import { Column } from "../dataModels/dataModelTypes";
 import { ClickHouseEngines, ApiUtil } from "../index";
 import { OlapTable } from "./sdk/olapTable";
-import { ConsumerConfig, Stream, TransformConfig } from "./sdk/stream";
+import {
+  ConsumerConfig,
+  KafkaSchemaConfig,
+  Stream,
+  TransformConfig,
+} from "./sdk/stream";
 import { compilerLog } from "../commons";
 
 /**
@@ -124,19 +129,6 @@ interface Consumer {
   version?: string;
 }
 
-/**
- * JSON representation of a Stream/Topic configuration.
- */
-type SchemaRegistryReferenceJson =
-  | { Id: number }
-  | { Latest: { subject_name: string } }
-  | { SubjectVersion: { name: string; version: number } };
-
-interface SchemaRegistryJson {
-  kind: "JSON" | "AVRO" | "PROTOBUF";
-  reference: SchemaRegistryReferenceJson;
-}
-
 interface StreamJson {
   /** The name of the stream/topic. */
   name: string;
@@ -163,7 +155,7 @@ interface StreamJson {
   /** Lifecycle management setting for the stream. */
   lifeCycle?: string;
   /** Optional minimal Schema Registry config */
-  schema_config?: SchemaRegistryJson;
+  schemaConfig?: KafkaSchemaConfig;
 }
 /**
  * JSON representation of an Ingest API configuration.

--- a/packages/ts-moose-lib/src/dmv2/internal.ts
+++ b/packages/ts-moose-lib/src/dmv2/internal.ts
@@ -129,6 +129,9 @@ interface Consumer {
   version?: string;
 }
 
+/**
+ * JSON representation of a Stream/Topic configuration.
+ */
 interface StreamJson {
   /** The name of the stream/topic. */
   name: string;
@@ -154,7 +157,7 @@ interface StreamJson {
   metadata?: { description?: string };
   /** Lifecycle management setting for the stream. */
   lifeCycle?: string;
-  /** Optional minimal Schema Registry config */
+  /** Optional Schema Registry config */
   schemaConfig?: KafkaSchemaConfig;
 }
 /**

--- a/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
@@ -425,7 +425,7 @@ export class Stream<T> extends TypedBase<T, StreamConfig<T>> {
 
       const encoded = await Promise.all(
         flat.map((v) =>
-          registry.encode(schemaId!, v as unknown as Record<string, unknown>),
+          registry.encode(schemaId, v as unknown as Record<string, unknown>),
         ),
       );
       await producer.send({

--- a/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
+++ b/packages/ts-moose-lib/src/dmv2/sdk/stream.ts
@@ -127,6 +127,19 @@ export interface ConsumerConfig<T> {
   deadLetterQueue?: DeadLetterQueue<T> | null;
 }
 
+// Minimal Schema Registry configuration
+export type SchemaRegistryEncoding = "JSON" | "AVRO" | "PROTOBUF";
+
+export type SchemaRegistryReference =
+  | { Id: number }
+  | { Latest: { subject_name: string } }
+  | { SubjectVersion: { name: string; version: number } };
+
+export interface SchemaRegistryConfig {
+  kind: SchemaRegistryEncoding;
+  reference: SchemaRegistryReference;
+}
+
 /**
  * Represents a message routed to a specific destination stream.
  * Used internally by the multi-transform functionality to specify
@@ -178,6 +191,9 @@ export interface StreamConfig<T> {
   lifeCycle?: LifeCycle;
 
   defaultDeadLetterQueue?: DeadLetterQueue<T>;
+
+  /** Optional Schema Registry configuration for this stream */
+  schemaRegistry?: SchemaRegistryConfig;
 }
 
 /**

--- a/packages/ts-moose-lib/src/streaming-functions/runner.ts
+++ b/packages/ts-moose-lib/src/streaming-functions/runner.ts
@@ -384,7 +384,16 @@ const handleMessage = async (
   }
 
   try {
-    const parsedData = JSON.parse(message.value.toString(), jsonDateReviver);
+    // Detect Schema Registry JSON envelope: 0x00 + 4-byte schema ID (big-endian) + JSON bytes
+    let payloadBuffer = message.value as Buffer;
+    if (
+      payloadBuffer &&
+      payloadBuffer.length >= 5 &&
+      payloadBuffer[0] === 0x00
+    ) {
+      payloadBuffer = payloadBuffer.subarray(5);
+    }
+    const parsedData = JSON.parse(payloadBuffer.toString(), jsonDateReviver);
     const transformedData = await Promise.all(
       streamingFunctionWithConfigList.map(async ([fn, config]) => {
         try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,9 @@ importers:
       '@confluentinc/kafka-javascript':
         specifier: 1.5.0
         version: 1.5.0
+      '@kafkajs/confluent-schema-registry':
+        specifier: 3.9.0
+        version: 3.9.0
       '@temporalio/activity':
         specifier: ^1.11.7
         version: 1.11.8
@@ -550,7 +553,7 @@ importers:
         version: 1.11.8
       '@temporalio/worker':
         specifier: ^1.11.7
-        version: 1.11.8(@swc/helpers@0.5.17)
+        version: 1.11.8(@swc/helpers@0.5.17)(esbuild@0.25.5)
       '@temporalio/workflow':
         specifier: ^1.11.7
         version: 1.11.8
@@ -1525,6 +1528,9 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@kafkajs/confluent-schema-registry@3.9.0':
+    resolution: {integrity: sha512-QiwinzNVlHPvylFCSiKBcTDxNDp9/xDj7ZWTxlsel5h4hwLxMLjnuJUcW/LhzNPPi/V4Vfa4Yq0uv30CYGtRnA==}
 
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
@@ -3428,6 +3434,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@7.2.4:
+    resolution: {integrity: sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==}
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
@@ -3570,6 +3579,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  avsc@5.7.9:
+    resolution: {integrity: sha512-yOA4wFeI7ET3v32Di/sUybQ+ttP20JHSW3mxLuNGeO0uD6PPcvLrIQXSvy/rhJOWU5JrYh7U4OHplWMmtAtjMg==}
+    engines: {node: '>=0.11'}
 
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
@@ -4230,8 +4243,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  detect-libc@2.1.0:
-    resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
+  detect-libc@2.1.1:
+    resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
     engines: {node: '>=8'}
 
   detect-newline@3.1.0:
@@ -5761,6 +5774,9 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  mappersmith@2.46.0:
+    resolution: {integrity: sha512-HE1kFZmVGuffVFDqZvqWIMn0GVNQU/JRr7ClrJjsuTslmM7fDgiukLK6I7ewio51PfxlrMEcdAe9xtcpx0nh7w==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -9165,9 +9181,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@kafkajs/confluent-schema-registry@3.9.0':
+    dependencies:
+      ajv: 7.2.4
+      avsc: 5.7.9
+      mappersmith: 2.46.0
+      protobufjs: 7.4.0
+
   '@mapbox/node-pre-gyp@1.0.11':
     dependencies:
-      detect-libc: 2.1.0
+      detect-libc: 2.1.1
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
       node-fetch: 2.7.0
@@ -10620,7 +10643,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.4.0
 
-  '@temporalio/worker@1.11.8(@swc/helpers@0.5.17)':
+  '@temporalio/worker@1.11.8(@swc/helpers@0.5.17)(esbuild@0.25.5)':
     dependencies:
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
       '@temporalio/activity': 1.11.8
@@ -10634,11 +10657,11 @@ snapshots:
       memfs: 4.17.2
       rxjs: 7.8.2
       source-map: 0.7.4
-      source-map-loader: 4.0.2(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      source-map-loader: 4.0.2(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5))
       supports-color: 8.1.1
-      swc-loader: 0.2.6(@swc/core@1.11.29(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      swc-loader: 0.2.6(@swc/core@1.11.29(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5))
       unionfs: 4.5.4
-      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))
+      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)
     transitivePeerDependencies:
       - '@swc/helpers'
       - esbuild
@@ -11506,6 +11529,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@7.2.4:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -11663,6 +11693,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  avsc@5.7.9: {}
 
   axe-core@4.10.3: {}
 
@@ -12358,7 +12390,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.1.0: {}
+  detect-libc@2.1.1: {}
 
   detect-newline@3.1.0: {}
 
@@ -12616,8 +12648,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -12666,7 +12698,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@8.1.1)
@@ -12677,7 +12709,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12703,7 +12735,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12718,7 +12750,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -14543,6 +14575,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  mappersmith@2.46.0: {}
+
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
@@ -16315,11 +16349,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@4.0.2(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))):
+  source-map-loader@4.0.2(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))
+      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)
 
   source-map-support@0.5.13:
     dependencies:
@@ -16518,11 +16552,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.11.29(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))):
+  swc-loader@0.2.6(@swc/core@1.11.29(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)):
     dependencies:
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
       '@swc/counter': 0.1.3
-      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))
+      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)
 
   symbol-tree@3.2.4: {}
 
@@ -16632,6 +16666,18 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  terser-webpack-plugin@5.3.14(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 4.3.2
+      serialize-javascript: 6.0.2
+      terser: 5.40.0
+      webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)
+    optionalDependencies:
+      '@swc/core': 1.11.29(@swc/helpers@0.5.17)
+      esbuild: 0.25.5
+
   terser-webpack-plugin@5.3.14(@swc/core@1.11.29(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -16642,6 +16688,7 @@ snapshots:
       webpack: 5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))
     optionalDependencies:
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
+    optional: true
 
   terser@5.40.0:
     dependencies:
@@ -17337,6 +17384,38 @@ snapshots:
       schema-utils: 4.3.2
       tapable: 2.2.2
       terser-webpack-plugin: 5.3.14(@swc/core@1.11.29(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      watchpack: 2.4.4
+      webpack-sources: 3.3.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
+
+  webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.7
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.14.1
+      browserslist: 4.24.5
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.2
+      tapable: 2.2.2
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5)(webpack@5.99.9(@swc/core@1.11.29(@swc/helpers@0.5.17))(esbuild@0.25.5))
       watchpack: 2.4.4
       webpack-sources: 3.3.0
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add end-to-end Confluent Schema Registry (JSON) support with CLI topic/schema pull, wire-format (magic byte + schema id) on produce/consume, and infra/proto/runtime updates across Rust, Python, and TypeScript.
> 
> - **Streaming/Kafka**:
>   - Add Schema Registry JSON integration: optional `schema_config` on `Topic`; resolve schema IDs; produce with Confluent envelope (0x00 + schema id); consumers/sync strip envelope.
>   - Introduce `schema_registry_url` in Kafka config (Rust, Python, TS).
> - **CLI**:
>   - New `kafka pull` command to discover topics and generate external stream declarations; optionally fetch JSON Schemas and emit typed models (TS/Python).
>   - Ingestion server resolves schema IDs per route and includes in `RouteMeta`.
> - **Runtimes/Libraries**:
>   - Python: support Schema Registry JSON via `confluent-kafka` serializer in `Stream.send`; add config/env plumbing.
>   - TypeScript: add `@kafkajs/confluent-schema-registry`; encode messages with registry; adjust runner to strip envelope.
> - **Infrastructure/Protocol**:
>   - Extend `infrastructure_map.proto` and Rust models with `SchemaRegistry` (encoding + subject/version/id).
> - **Data path fixes**:
>   - ClickHouse/Kafka sync and runners handle JSON envelope; minor UTF-8 handling and validation improvements.
> - **Deps**:
>   - Add `schema-registry-client` (Rust), `@kafkajs/confluent-schema-registry` (TS), `confluent-kafka[json,schemaregistry]` (Py); assorted version bumps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b34a37a38280b1cfabfab13fa2562acd2d7bb938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->