### PR TITLE
set up the project for exports

### DIFF
--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -1,10 +1,13 @@
 {
   "name": "ts",
   "version": "0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "moose": "moose-cli",
     "build": "moose-cli build --docker",
-    "dev": "moose-cli dev"
+    "dev": "moose-cli dev",
+    "exports": "./node_modules/.bin/tspc app/index.ts"
   },
   "dependencies": {
     "@514labs/moose-lib": "latest",

--- a/templates/typescript/tsconfig.json
+++ b/templates/typescript/tsconfig.json
@@ -11,6 +11,7 @@
         "transform": "typia/lib/transform"
       }
     ],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
this sets up the templated typescript project to enable exporting types and runtime for a byof app to consume.