### PR TITLE
ingestapi schema backward compatible fix

### DIFF
--- a/apps/framework-cli/src/framework/core/infrastructure/api_endpoint.rs
+++ b/apps/framework-cli/src/framework/core/infrastructure/api_endpoint.rs
@@ -29,6 +29,7 @@ pub enum APIType {
         // that's a different level of abstraction
         data_model: Option<Box<DataModel>>,
         dead_letter_queue: Option<String>,
+        #[serde(default)]
         schema: serde_json::Map<String, Value>,
     },
     EGRESS {

--- a/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
+++ b/apps/framework-cli/src/framework/core/partial_infrastructure_map.rs
@@ -210,6 +210,7 @@ struct PartialIngestApi {
     /// If not specified, defaults to "ingest/{name}/{version}"
     #[serde(default)]
     pub path: Option<String>,
+    #[serde(default)]
     pub schema: serde_json::Map<String, serde_json::Value>,
 }
 


### PR DESCRIPTION
Seeing an a plan error when trying to bump hosting_telemetry_app:

```
Failed to plan changes: error decoding response body
Caused by: missing field `schema` at line 1 column 2582
```

Running plan for hosting_telemetry_app locally shows no changes now.