### PR TITLE
remove prettyms

### DIFF
--- a/packages/ts-moose-lib/package.json
+++ b/packages/ts-moose-lib/package.json
@@ -43,7 +43,6 @@
     "fastq": "1.17.1",
     "jose": "5.9.2",
     "@confluentinc/kafka-javascript": "1.5.0",
-    "pretty-ms": "9.2.0",
     "redis": "^4.6.13",
     "toml": "3.0.0",
     "ts-node": "^10.9.1",

--- a/packages/ts-moose-lib/src/consumption-apis/helpers.ts
+++ b/packages/ts-moose-lib/src/consumption-apis/helpers.ts
@@ -7,11 +7,27 @@ import {
 import { StringValue } from "@temporalio/common";
 import { createHash, randomUUID } from "node:crypto";
 import { performance } from "perf_hooks";
-import prettyMs from "pretty-ms";
 import * as fs from "fs";
 import { getWorkflows } from "../dmv2/internal";
 import { JWTPayload } from "jose";
 import { Sql, sql, RawValue, toQuery, toQueryPreview } from "../sqlHelpers";
+
+/**
+ * Format elapsed milliseconds into a human-readable string.
+ * Matches Python's format_timespan behavior.
+ */
+function formatElapsedTime(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)} ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(2)} seconds`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes} minutes and ${remainingSeconds.toFixed(2)} seconds`;
+}
 
 export interface ApiUtil {
   client: MooseClient;
@@ -58,7 +74,9 @@ export class QueryClient {
       // where response buffering would harm streaming performance and concurrency
     });
     const elapsedMs = performance.now() - start;
-    console.log(`[QueryClient] | Query completed: ${prettyMs(elapsedMs)}`);
+    console.log(
+      `[QueryClient] | Query completed: ${formatElapsedTime(elapsedMs)}`,
+    );
     return result;
   }
 
@@ -73,7 +91,9 @@ export class QueryClient {
       query_id: this.query_id_prefix + randomUUID(),
     });
     const elapsedMs = performance.now() - start;
-    console.log(`[QueryClient] | Command completed: ${prettyMs(elapsedMs)}`);
+    console.log(
+      `[QueryClient] | Command completed: ${formatElapsedTime(elapsedMs)}`,
+    );
     return result;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,9 +566,6 @@ importers:
       jose:
         specifier: 5.9.2
         version: 5.9.2
-      pretty-ms:
-        specifier: 9.2.0
-        version: 9.2.0
       redis:
         specifier: ^4.6.13
         version: 4.7.1
@@ -6354,10 +6351,6 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
-
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
@@ -6550,10 +6543,6 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  pretty-ms@9.2.0:
-    resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
-    engines: {node: '>=18'}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -15523,8 +15512,6 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
-  parse-ms@4.0.0: {}
-
   parse-numeric-range@1.3.0: {}
 
   parse5@7.3.0:
@@ -15698,10 +15685,6 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
-
-  pretty-ms@9.2.0:
-    dependencies:
-      parse-ms: 4.0.0
 
   progress@2.0.3: {}
 


### PR DESCRIPTION
Causing issues in some node versions < 22.12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace pretty-ms with a local time formatting utility and remove the dependency across code and lockfile.
> 
> - **ts-moose-lib**:
>   - **Logging**: Replace `pretty-ms` with local `formatElapsedTime(ms)` in `src/consumption-apis/helpers.ts` for query/command duration logs.
>   - **Dependencies**: Remove `pretty-ms` from `packages/ts-moose-lib/package.json` and purge related entries from `pnpm-lock.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79cc657ded9766f72dd612bc46540265b690949c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->